### PR TITLE
Expose SurrealDB port for local access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       - ./surreal_data:/mydata
     environment:
       - SURREAL_EXPERIMENTAL_GRAPHQL=true
+    ports:
+      - "8000:8000"
     command: start --log info --user root --pass root rocksdb:/mydata/mydatabase.db
     pull_policy: always
     user: root


### PR DESCRIPTION
## Summary
- expose port 8000 from the SurrealDB container so local clients can connect
- ensure `make start-all` migrations reach the database running in Docker

## Testing
- `uv run --env-file .env ruff check .` *(fails: repo has existing lint violations in api/ and pages modules)*
- `uv run --env-file .env python -m mypy .` *(fails: existing syntax error reported at open_notebook/graphs/ask.py:20)*
