### PR TITLE
Add GHCR support with conditional Docker Hub publishing

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -20,6 +20,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   # Dynamic registry and image configuration based on repository
   GHCR_REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary

This PR adds GitHub Container Registry (GHCR) support to the build workflow, while making Docker Hub publishing optional and conditional on the presence of credentials.

## Motivation

Currently, the workflow only supports Docker Hub and requires `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets. This creates barriers for:
- Fork maintainers who want to build and publish their own images without Docker Hub accounts
- Contributors testing CI changes before submitting PRs  
- Organizations preferring GHCR for internal deployments

## Changes

### Registry Support
- **Primary Registry**: GitHub Container Registry (GHCR) - always enabled
- **Secondary Registry**: Docker Hub - conditional on secrets being configured
- Images are automatically named based on the repository (e.g., `aperim/open-notebook` → `ghcr.io/aperim/open-notebook`)

### Workflow Enhancements

1. **Dynamic Image Naming**
   - Extracts owner and repo name from `$GITHUB_REPOSITORY`
   - GHCR images: `ghcr.io/{owner}/{repo}:{tag}`
   - Docker Hub images: `{owner}/{repo}:{tag}`

2. **Conditional Docker Hub Publishing**
   - Checks for `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets
   - Only attempts Docker Hub login/push if both secrets are present
   - Gracefully skips Docker Hub when credentials unavailable

3. **Enhanced Build Summary**
   - Shows which registries were used
   - Lists all pushed image tags for each registry
   - Clearly indicates when Docker Hub was skipped

### Technical Details

- Added new job outputs: `ghcr_image`, `dockerhub_image`, `has_dockerhub_secrets`
- GHCR login uses `GITHUB_TOKEN` (automatically available in all repos)
- Docker Hub login wrapped in conditional check
- Image tags dynamically generated based on registry availability
- No breaking changes to existing workflows

## Testing

- [ ] Workflow syntax validated
- [ ] Ready for testing on aperim/open-notebook fork
- [ ] Will publish to GHCR without Docker Hub credentials
- [ ] Original repo can continue publishing to both registries

## Benefits

✅ **For Forks**: Build and publish to GHCR without additional setup  
✅ **For Original Repo**: Continue publishing to both Docker Hub and GHCR  
✅ **For Contributors**: Test CI changes without Docker Hub access  
✅ **For Users**: More deployment options (GHCR or Docker Hub)

## Backwards Compatibility

This change is **fully backwards compatible**:
- Repos with Docker Hub secrets configured will continue publishing to both registries
- Repos without Docker Hub secrets will only publish to GHCR (new capability)
- No changes required to existing secrets or configurations

## Example Output

### With Docker Hub Credentials
```
Registries:
✅ GHCR: ghcr.io/lfnovo/open-notebook
✅ Docker Hub: lfnovo/open_notebook

Images Built:
✅ Regular (GHCR): ghcr.io/lfnovo/open-notebook:0.6.5
✅ Regular Latest (GHCR): ghcr.io/lfnovo/open-notebook:latest
✅ Regular (Docker Hub): lfnovo/open_notebook:0.6.5
✅ Regular Latest (Docker Hub): lfnovo/open_notebook:latest
```

### Without Docker Hub Credentials
```
Registries:
✅ GHCR: ghcr.io/aperim/open-notebook
⏭️ Docker Hub: Skipped (credentials not configured)

Images Built:
✅ Regular (GHCR): ghcr.io/aperim/open-notebook:0.6.5
✅ Regular Latest (GHCR): ghcr.io/aperim/open-notebook:latest
```

## Related Issues

This addresses the need for more flexible container publishing options, especially for forks and contributors.
