### PR TITLE
Add GitHub Container Registry (GHCR) support

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -20,6 +20,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   # Dynamic registry and image configuration based on repository
   GHCR_REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary

This PR adds support for publishing container images to GitHub Container Registry (GHCR) alongside existing Docker Hub publishing.

## Problem

Currently, Open Notebook only publishes to Docker Hub. Organizations may prefer or require using GHCR for container distribution, especially for GitHub-centric workflows.

## Solution

Modified the build workflows to:
- Add GHCR authentication using `GITHUB_TOKEN`
- Publish images to both `ghcr.io/lfnovo/open-notebook` and Docker Hub
- Make Docker Hub publishing conditional on credentials being available
- Add required `packages: write` permission for GHCR publishing

## Changes

- `.github/workflows/build-and-release.yml`: Added GHCR support with conditional Docker Hub
- `.github/workflows/build-dev.yml`: Added GHCR support with conditional Docker Hub

## Testing

- Verified images build and push to GHCR successfully
- Confirmed Docker Hub still works when credentials provided
- Tested workflow runs without Docker Hub credentials

## Related PRs

This PR is part of a series of improvements to Open Notebook:
- #152 - Increase source creation timeout
- #153 - Fix Anthropic API temperature/top_p conflict  
- #154 - Fix ruff linting errors
- #155 - Add GPT-5 extended thinking support for podcasts
- #156 - Fix Python syntax errors and make mypy non-blocking

While independent, these PRs together improve CI/CD reliability and model compatibility.