### PR TITLE
feat: Add provider API key settings UI

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -257,6 +257,7 @@ class SettingsResponse(BaseModel):
     default_embedding_option: Optional[str] = None
     auto_delete_files: Optional[str] = None
     youtube_preferred_languages: Optional[List[str]] = None
+    provider_credentials: Optional[Dict[str, Optional[str]]] = None
 
 
 class SettingsUpdate(BaseModel):
@@ -265,6 +266,7 @@ class SettingsUpdate(BaseModel):
     default_embedding_option: Optional[str] = None
     auto_delete_files: Optional[str] = None
     youtube_preferred_languages: Optional[List[str]] = None
+    provider_credentials: Optional[Dict[str, Optional[str]]] = None
 
 
 # Sources API models

--- a/api/routers/settings.py
+++ b/api/routers/settings.py
@@ -1,3 +1,5 @@
+import os
+
 from fastapi import APIRouter, HTTPException
 from loguru import logger
 
@@ -14,12 +16,15 @@ async def get_settings():
     try:
         settings: ContentSettings = await ContentSettings.get_instance()  # type: ignore[assignment]
 
+        settings.apply_provider_credentials()
+
         return SettingsResponse(
             default_content_processing_engine_doc=settings.default_content_processing_engine_doc,
             default_content_processing_engine_url=settings.default_content_processing_engine_url,
             default_embedding_option=settings.default_embedding_option,
             auto_delete_files=settings.auto_delete_files,
             youtube_preferred_languages=settings.youtube_preferred_languages,
+            provider_credentials=settings.provider_credentials or {},
         )
     except Exception as e:
         logger.error(f"Error fetching settings: {str(e)}")
@@ -61,7 +66,42 @@ async def update_settings(settings_update: SettingsUpdate):
         if settings_update.youtube_preferred_languages is not None:
             settings.youtube_preferred_languages = settings_update.youtube_preferred_languages
 
+        if settings_update.provider_credentials is not None:
+            if settings.provider_credentials is None:
+                settings.provider_credentials = {}
+
+            for raw_key, raw_value in settings_update.provider_credentials.items():
+                if raw_key is None:
+                    continue
+
+                normalized_key = raw_key.strip()
+                if not normalized_key:
+                    continue
+
+                normalized_key = normalized_key.upper()
+
+                if raw_value is None:
+                    settings.provider_credentials.pop(normalized_key, None)
+                    os.environ.pop(normalized_key, None)
+                    continue
+
+                trimmed_value = raw_value.strip()
+                if trimmed_value:
+                    settings.provider_credentials[normalized_key] = trimmed_value
+                    os.environ[normalized_key] = trimmed_value
+                else:
+                    settings.provider_credentials.pop(normalized_key, None)
+                    os.environ.pop(normalized_key, None)
+
+            settings.provider_credentials = {
+                key: value
+                for key, value in settings.provider_credentials.items()
+                if value
+            }
+
         await settings.update()
+
+        settings.apply_provider_credentials()
 
         return SettingsResponse(
             default_content_processing_engine_doc=settings.default_content_processing_engine_doc,
@@ -69,6 +109,7 @@ async def update_settings(settings_update: SettingsUpdate):
             default_embedding_option=settings.default_embedding_option,
             auto_delete_files=settings.auto_delete_files,
             youtube_preferred_languages=settings.youtube_preferred_languages,
+            provider_credentials=settings.provider_credentials or {},
         )
     except HTTPException:
         raise

--- a/frontend/src/app/(dashboard)/settings/components/SettingsForm.tsx
+++ b/frontend/src/app/(dashboard)/settings/components/SettingsForm.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import { useForm, Controller } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
@@ -11,14 +12,194 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
 import { useSettings, useUpdateSettings } from '@/lib/hooks/use-settings'
-import { useEffect, useState } from 'react'
 import { ChevronDownIcon } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import { SettingsResponse } from '@/lib/types/api'
 
+interface ProviderFieldConfig {
+  env: string
+  label: string
+  type?: 'text' | 'password'
+  placeholder?: string
+  helper?: string
+}
+
+interface ProviderConfig {
+  id: string
+  name: string
+  description?: string
+  fields: ProviderFieldConfig[]
+}
+
+const PROVIDER_CONFIGS: ProviderConfig[] = [
+  {
+    id: 'openai',
+    name: 'OpenAI',
+    description: 'Used for GPT models, Whisper, and text-to-speech.',
+    fields: [
+      {
+        env: 'OPENAI_API_KEY',
+        label: 'API Key',
+        placeholder: 'sk-...',
+        type: 'password',
+      },
+    ],
+  },
+  {
+    id: 'azure',
+    name: 'Azure OpenAI',
+    description: 'Configure when using Azure-hosted OpenAI deployments.',
+    fields: [
+      { env: 'AZURE_OPENAI_API_KEY', label: 'API Key', type: 'password' },
+      {
+        env: 'AZURE_OPENAI_ENDPOINT',
+        label: 'Endpoint URL',
+        type: 'text',
+        placeholder: 'https://your-resource.openai.azure.com',
+      },
+      { env: 'AZURE_OPENAI_DEPLOYMENT_NAME', label: 'Deployment Name', type: 'text' },
+      {
+        env: 'AZURE_OPENAI_API_VERSION',
+        label: 'API Version',
+        type: 'text',
+        helper: 'Example: 2024-12-01-preview',
+      },
+    ],
+  },
+  {
+    id: 'anthropic',
+    name: 'Anthropic',
+    description: 'Claude models for chat and tools.',
+    fields: [{ env: 'ANTHROPIC_API_KEY', label: 'API Key', type: 'password' }],
+  },
+  {
+    id: 'google',
+    name: 'Google / Gemini',
+    description: 'Gemini models for chat, embeddings, and speech.',
+    fields: [
+      { env: 'GEMINI_API_KEY', label: 'Gemini API Key', type: 'password' },
+      {
+        env: 'GOOGLE_API_KEY',
+        label: 'Legacy Google API Key',
+        type: 'password',
+        helper: 'Only required for some older Gemini setups.',
+      },
+    ],
+  },
+  {
+    id: 'vertex',
+    name: 'Vertex AI',
+    description: 'Google Cloud Vertex AI models.',
+    fields: [
+      { env: 'VERTEX_PROJECT', label: 'Project ID', type: 'text' },
+      { env: 'VERTEX_LOCATION', label: 'Location', type: 'text' },
+      {
+        env: 'GOOGLE_APPLICATION_CREDENTIALS',
+        label: 'Service Account JSON Path',
+        type: 'text',
+        helper: 'Absolute path to the service account JSON file accessible by the API container.',
+      },
+    ],
+  },
+  {
+    id: 'groq',
+    name: 'Groq',
+    description: 'Groq hosted Llama and Mixtral models.',
+    fields: [{ env: 'GROQ_API_KEY', label: 'API Key', type: 'password' }],
+  },
+  {
+    id: 'mistral',
+    name: 'Mistral',
+    description: 'Mistral AI hosted models.',
+    fields: [{ env: 'MISTRAL_API_KEY', label: 'API Key', type: 'password' }],
+  },
+  {
+    id: 'deepseek',
+    name: 'DeepSeek',
+    description: 'DeepSeek chat and reasoning models.',
+    fields: [{ env: 'DEEPSEEK_API_KEY', label: 'API Key', type: 'password' }],
+  },
+  {
+    id: 'xai',
+    name: 'xAI',
+    description: 'Grok models provided by xAI.',
+    fields: [{ env: 'XAI_API_KEY', label: 'API Key', type: 'password' }],
+  },
+  {
+    id: 'openrouter',
+    name: 'OpenRouter',
+    description: 'Router for accessing community hosted models.',
+    fields: [{ env: 'OPENROUTER_API_KEY', label: 'API Key', type: 'password' }],
+  },
+  {
+    id: 'voyage',
+    name: 'Voyage AI',
+    description: 'High quality embeddings and rerankers.',
+    fields: [{ env: 'VOYAGE_API_KEY', label: 'API Key', type: 'password' }],
+  },
+  {
+    id: 'elevenlabs',
+    name: 'ElevenLabs',
+    description: 'Text-to-speech voices.',
+    fields: [{ env: 'ELEVENLABS_API_KEY', label: 'API Key', type: 'password' }],
+  },
+  {
+    id: 'ollama',
+    name: 'Ollama',
+    description: 'Local models served via Ollama.',
+    fields: [
+      {
+        env: 'OLLAMA_API_BASE',
+        label: 'API Base URL',
+        type: 'text',
+        placeholder: 'http://localhost:11434',
+      },
+    ],
+  },
+  {
+    id: 'openai_compatible',
+    name: 'OpenAI Compatible',
+    description: 'Generic OpenAI-compatible endpoints (LM Studio, LocalAI, vLLM, etc.).',
+    fields: [
+      {
+        env: 'OPENAI_COMPATIBLE_BASE_URL',
+        label: 'Default Base URL',
+        type: 'text',
+        placeholder: 'http://localhost:1234/v1',
+      },
+      { env: 'OPENAI_COMPATIBLE_API_KEY', label: 'Default API Key', type: 'password' },
+      {
+        env: 'OPENAI_COMPATIBLE_BASE_URL_LLM',
+        label: 'LLM Base URL',
+        type: 'text',
+        helper: 'Overrides the default base URL for chat models.',
+      },
+      { env: 'OPENAI_COMPATIBLE_API_KEY_LLM', label: 'LLM API Key', type: 'password' },
+      { env: 'OPENAI_COMPATIBLE_BASE_URL_EMBEDDING', label: 'Embedding Base URL', type: 'text' },
+      { env: 'OPENAI_COMPATIBLE_API_KEY_EMBEDDING', label: 'Embedding API Key', type: 'password' },
+      { env: 'OPENAI_COMPATIBLE_BASE_URL_STT', label: 'Speech-to-Text Base URL', type: 'text' },
+      { env: 'OPENAI_COMPATIBLE_API_KEY_STT', label: 'Speech-to-Text API Key', type: 'password' },
+      { env: 'OPENAI_COMPATIBLE_BASE_URL_TTS', label: 'Text-to-Speech Base URL', type: 'text' },
+      { env: 'OPENAI_COMPATIBLE_API_KEY_TTS', label: 'Text-to-Speech API Key', type: 'password' },
+    ],
+  },
+  {
+    id: 'content_extraction',
+    name: 'Content Extraction',
+    description: 'Optional keys for Firecrawl and Jina when processing URLs.',
+    fields: [
+      { env: 'FIRECRAWL_API_KEY', label: 'Firecrawl API Key', type: 'password' },
+      { env: 'JINA_API_KEY', label: 'Jina API Key', type: 'password' },
+    ],
+  },
+]
 const settingsSchema = z.object({
   default_content_processing_engine_doc: z.enum(['auto', 'docling', 'simple']).optional(),
   default_content_processing_engine_url: z.enum(['auto', 'firecrawl', 'jina', 'simple']).optional(),
   default_embedding_option: z.enum(['ask', 'always', 'never']).optional(),
   auto_delete_files: z.enum(['yes', 'no']).optional(),
+  provider_credentials: z.record(z.string(), z.string().optional()).optional(),
 })
 
 type SettingsFormData = z.infer<typeof settingsSchema>
@@ -27,14 +208,14 @@ export function SettingsForm() {
   const { data: settings, isLoading, error } = useSettings()
   const updateSettings = useUpdateSettings()
   const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({})
-  const [hasResetForm, setHasResetForm] = useState(false)
-  
-  
+
   const {
     control,
     handleSubmit,
     reset,
-    formState: { isDirty }
+    register,
+    watch,
+    formState: { isDirty },
   } = useForm<SettingsFormData>({
     resolver: zodResolver(settingsSchema),
     defaultValues: {
@@ -42,29 +223,82 @@ export function SettingsForm() {
       default_content_processing_engine_url: undefined,
       default_embedding_option: undefined,
       auto_delete_files: undefined,
-    }
+      provider_credentials: {},
+    },
   })
 
-
   const toggleSection = (section: string) => {
-    setExpandedSections(prev => ({ ...prev, [section]: !prev[section] }))
+    setExpandedSections((prev) => ({ ...prev, [section]: !prev[section] }))
   }
 
   useEffect(() => {
-    if (settings && settings.default_content_processing_engine_doc && !hasResetForm) {
-      const formData = {
-        default_content_processing_engine_doc: settings.default_content_processing_engine_doc as 'auto' | 'docling' | 'simple',
-        default_content_processing_engine_url: settings.default_content_processing_engine_url as 'auto' | 'firecrawl' | 'jina' | 'simple',
-        default_embedding_option: settings.default_embedding_option as 'ask' | 'always' | 'never',
-        auto_delete_files: settings.auto_delete_files as 'yes' | 'no',
-      }
-      reset(formData)
-      setHasResetForm(true)
+    if (!settings) {
+      return
     }
-  }, [hasResetForm, reset, settings])
+
+    const providerCredentials = Object.fromEntries(
+      Object.entries(settings.provider_credentials ?? {}).map(([key, value]) => [
+        key,
+        value ?? '',
+      ]),
+    ) as Record<string, string>
+
+    reset({
+      default_content_processing_engine_doc: (settings.default_content_processing_engine_doc ?? undefined) as
+        | 'auto'
+        | 'docling'
+        | 'simple'
+        | undefined,
+      default_content_processing_engine_url: (settings.default_content_processing_engine_url ?? undefined) as
+        | 'auto'
+        | 'firecrawl'
+        | 'jina'
+        | 'simple'
+        | undefined,
+      default_embedding_option: (settings.default_embedding_option ?? undefined) as
+        | 'ask'
+        | 'always'
+        | 'never'
+        | undefined,
+      auto_delete_files: (settings.auto_delete_files ?? undefined) as 'yes' | 'no' | undefined,
+      provider_credentials: providerCredentials,
+    })
+  }, [reset, settings])
+
+  const providerCredentials = watch('provider_credentials') || {}
 
   const onSubmit = async (data: SettingsFormData) => {
-    await updateSettings.mutateAsync(data)
+    const { provider_credentials, ...rest } = data
+
+    const existingCredentials = settings?.provider_credentials ?? {}
+    const providerUpdates: Record<string, string | null> = {}
+    const formCredentials = provider_credentials ?? {}
+
+    const allKeys = new Set([
+      ...Object.keys(existingCredentials),
+      ...Object.keys(formCredentials),
+    ])
+
+    allKeys.forEach((key) => {
+      const rawValue = formCredentials[key]
+      const trimmedValue = rawValue?.trim()
+
+      if (trimmedValue) {
+        providerUpdates[key] = trimmedValue
+      } else if (key in existingCredentials) {
+        providerUpdates[key] = null
+      }
+    })
+
+    const payload: Partial<SettingsResponse> = {
+      ...rest,
+    }
+
+    if (Object.keys(providerUpdates).length > 0) {
+      payload.provider_credentials = providerUpdates
+    }
+
+    await updateSettings.mutateAsync(payload)
   }
 
   if (isLoading) {
@@ -85,7 +319,6 @@ export function SettingsForm() {
       </Alert>
     )
   }
-
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
       <Card>
@@ -108,15 +341,15 @@ export function SettingsForm() {
                   onValueChange={field.onChange}
                   disabled={field.disabled || isLoading}
                 >
-                    <SelectTrigger className="w-full">
-                      <SelectValue placeholder="Select document processing engine" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="auto">Auto (Recommended)</SelectItem>
-                      <SelectItem value="docling">Docling</SelectItem>
-                      <SelectItem value="simple">Simple</SelectItem>
-                    </SelectContent>
-                  </Select>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Select document processing engine" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="auto">Auto (Recommended)</SelectItem>
+                    <SelectItem value="docling">Docling</SelectItem>
+                    <SelectItem value="simple">Simple</SelectItem>
+                  </SelectContent>
+                </Select>
               )}
             />
             <Collapsible open={expandedSections.doc} onOpenChange={() => toggleSection('doc')}>
@@ -131,7 +364,7 @@ export function SettingsForm() {
               </CollapsibleContent>
             </Collapsible>
           </div>
-          
+
           <div className="space-y-3">
             <Label htmlFor="url_engine">URL Processing Engine</Label>
             <Controller
@@ -222,6 +455,70 @@ export function SettingsForm() {
 
       <Card>
         <CardHeader>
+          <CardTitle>AI Provider Credentials</CardTitle>
+          <CardDescription>
+            Save API keys and endpoints for the providers you use. Changes take effect immediately for new requests.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {PROVIDER_CONFIGS.map((provider) => {
+            const providerKey = `provider-${provider.id}`
+            const providerValues = provider.fields.map((field) => providerCredentials?.[field.env])
+            const isConfigured = providerValues.some(
+              (value) => typeof value === 'string' && value.trim().length > 0,
+            )
+
+            return (
+              <div key={provider.id} className="rounded-lg border border-border bg-card">
+                <button
+                  type="button"
+                  onClick={() => toggleSection(providerKey)}
+                  className="flex w-full items-center justify-between gap-4 rounded-t-lg p-4 text-left transition-colors hover:bg-muted/60"
+                  aria-expanded={Boolean(expandedSections[providerKey])}
+                >
+                  <div className="space-y-1">
+                    <p className="font-medium">{provider.name}</p>
+                    {provider.description && (
+                      <p className="text-sm text-muted-foreground">{provider.description}</p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <Badge variant={isConfigured ? 'default' : 'outline'} className="text-xs">
+                      {isConfigured ? 'Configured' : 'Not configured'}
+                    </Badge>
+                    <ChevronDownIcon
+                      className={`h-4 w-4 transition-transform ${expandedSections[providerKey] ? 'rotate-180' : ''}`}
+                    />
+                  </div>
+                </button>
+                {expandedSections[providerKey] && (
+                  <div className="space-y-4 border-t border-border p-4 pt-3">
+                    {provider.fields.map((field) => (
+                      <div key={field.env} className="space-y-2">
+                        <Label htmlFor={field.env}>{field.label}</Label>
+                        <Input
+                          id={field.env}
+                          type={field.type === 'text' ? 'text' : 'password'}
+                          placeholder={field.placeholder}
+                          autoComplete="off"
+                          spellCheck={false}
+                          {...register(`provider_credentials.${field.env}`)}
+                        />
+                        {field.helper && (
+                          <p className="text-xs text-muted-foreground">{field.helper}</p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
           <CardTitle>File Management</CardTitle>
           <CardDescription>
             Configure file handling and storage options
@@ -266,8 +563,8 @@ export function SettingsForm() {
       </Card>
 
       <div className="flex justify-end">
-        <Button 
-          type="submit" 
+        <Button
+          type="submit"
           disabled={!isDirty || updateSettings.isPending}
         >
           {updateSettings.isPending ? 'Saving...' : 'Save Settings'}

--- a/frontend/src/lib/hooks/use-settings.ts
+++ b/frontend/src/lib/hooks/use-settings.ts
@@ -8,6 +8,7 @@ export function useSettings() {
   return useQuery({
     queryKey: QUERY_KEYS.settings,
     queryFn: () => settingsApi.get(),
+    refetchOnWindowFocus: false,
   })
 }
 

--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -58,6 +58,7 @@ export interface SettingsResponse {
   default_embedding_option?: string
   auto_delete_files?: string
   youtube_preferred_languages?: string[]
+  provider_credentials?: Record<string, string | null>
 }
 
 export interface CreateNotebookRequest {

--- a/open_notebook/domain/content_settings.py
+++ b/open_notebook/domain/content_settings.py
@@ -1,4 +1,6 @@
-from typing import ClassVar, List, Literal, Optional
+from typing import ClassVar, Dict, List, Literal, Optional
+
+import os
 
 from pydantic import Field
 
@@ -23,3 +25,22 @@ class ContentSettings(RecordModel):
         ["en", "pt", "es", "de", "nl", "en-GB", "fr", "de", "hi", "ja"],
         description="Preferred languages for YouTube transcripts",
     )
+    provider_credentials: Dict[str, Optional[str]] = Field(
+        default_factory=dict,
+        description="Stored provider environment variables keyed by env var name",
+    )
+
+    def apply_provider_credentials(self) -> None:
+        """Apply stored provider credentials to process environment variables."""
+        for env_key, value in (self.provider_credentials or {}).items():
+            if not env_key:
+                continue
+
+            normalized_key = env_key.strip()
+            if not normalized_key:
+                continue
+
+            if value:
+                os.environ[normalized_key] = value
+            else:
+                os.environ.pop(normalized_key, None)

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -5,6 +5,8 @@ This test suite focuses on validation logic, business rules, and data structures
 that can be tested without database mocking.
 """
 
+import os
+
 import pytest
 from pydantic import ValidationError
 
@@ -252,6 +254,19 @@ class TestContentSettings:
         assert settings.default_embedding_option == "ask"
         assert settings.auto_delete_files == "yes"
         assert len(settings.youtube_preferred_languages) > 0
+        assert settings.provider_credentials == {}
+
+    def test_apply_provider_credentials_sets_environment(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        settings = ContentSettings()
+        settings.provider_credentials["OPENAI_API_KEY"] = "test-key"
+
+        settings.apply_provider_credentials()
+
+        assert os.environ.get("OPENAI_API_KEY") == "test-key"
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
 
 # ============================================================================

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -1,0 +1,111 @@
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from open_notebook.domain.content_settings import ContentSettings
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def fresh_settings():
+    ContentSettings.clear_instance()
+    settings = ContentSettings()
+    try:
+        yield settings
+    finally:
+        ContentSettings.clear_instance()
+
+
+def test_get_settings_returns_provider_credentials(monkeypatch, fresh_settings):
+    settings = fresh_settings
+    settings.provider_credentials = {"OPENAI_API_KEY": "sk-test"}
+
+    apply_calls = {"count": 0}
+
+    original_apply = ContentSettings.apply_provider_credentials
+
+    def tracked_apply(self):
+        apply_calls["count"] += 1
+        original_apply(self)
+
+    monkeypatch.setattr(
+        ContentSettings,
+        "apply_provider_credentials",
+        tracked_apply,
+    )
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    mock_get_instance = AsyncMock(return_value=settings)
+
+    with patch(
+        "api.routers.settings.ContentSettings.get_instance",
+        new=mock_get_instance,
+    ):
+        response = client.get("/api/settings")
+
+    mock_get_instance.assert_awaited_once()
+    assert apply_calls["count"] == 1
+    assert response.status_code == 200
+    assert response.json()["provider_credentials"] == {"OPENAI_API_KEY": "sk-test"}
+    assert os.environ["OPENAI_API_KEY"] == "sk-test"
+
+
+def test_update_settings_normalizes_provider_credentials(monkeypatch, fresh_settings):
+    settings = fresh_settings
+    settings.provider_credentials = {
+        "EXISTING_KEY": "keep-me",
+        "SHOULD_REMOVE": "value",
+    }
+    update_mock = AsyncMock(return_value=settings)
+    monkeypatch.setattr(ContentSettings, "update", update_mock)
+
+    apply_calls = {"count": 0}
+
+    original_apply = ContentSettings.apply_provider_credentials
+
+    def tracked_apply(self):
+        apply_calls["count"] += 1
+        original_apply(self)
+
+    monkeypatch.setattr(
+        ContentSettings,
+        "apply_provider_credentials",
+        tracked_apply,
+    )
+
+    monkeypatch.setenv("EXISTING_KEY", "keep-me")
+    monkeypatch.setenv("SHOULD_REMOVE", "value")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    payload = {
+        "provider_credentials": {
+            " openai_api_key ": "  new-key  ",
+            "existing_key": None,
+            "should_remove": "   ",
+        }
+    }
+
+    mock_get_instance = AsyncMock(return_value=settings)
+
+    with patch(
+        "api.routers.settings.ContentSettings.get_instance",
+        new=mock_get_instance,
+    ):
+        response = client.put("/api/settings", json=payload)
+
+    mock_get_instance.assert_awaited_once()
+    update_mock.assert_awaited_once()
+    assert apply_calls["count"] == 1
+
+    assert response.status_code == 200
+    assert response.json()["provider_credentials"] == {"OPENAI_API_KEY": "new-key"}
+
+    assert settings.provider_credentials == {"OPENAI_API_KEY": "new-key"}
+    assert os.environ.get("OPENAI_API_KEY") == "new-key"
+    assert "EXISTING_KEY" not in os.environ
+    assert "SHOULD_REMOVE" not in os.environ


### PR DESCRIPTION
Closes #195 

**Summary**

Added persistent provider_credentials support to ContentSettings with helpers that mirror the values into environment variables and added unit coverage for the new behavior.
Extended the settings API and startup flow to expose provider credentials, normalize incoming keys, synchronize them with os.environ, and return the stored values to clients.
Enhanced the dashboard settings experience by defining provider metadata, wiring form submission logic, and updating client types/hooks so users can manage provider credentials directly in the UI.

**Testing**

uv run pytest tests/test_settings_api.py
uv run pytest tests/test_domain.py