### PR TITLE
docs: update model help links to point to ai-models documentation

### DIFF
--- a/frontend/src/app/(dashboard)/models/components/DefaultModelsSection.tsx
+++ b/frontend/src/app/(dashboard)/models/components/DefaultModelsSection.tsx
@@ -231,7 +231,7 @@ export function DefaultModelsSection({ models, defaults }: DefaultModelsSectionP
 
         <div className="pt-4 border-t">
           <a
-            href="https://github.com/lfnovo/open-notebook/blob/main/docs/models.md"
+            href="https://github.com/lfnovo/open-notebook/blob/main/docs/features/ai-models.md"
             target="_blank"
             rel="noopener noreferrer"
             className="text-sm text-primary hover:underline"

--- a/frontend/src/app/(dashboard)/models/components/ProviderStatus.tsx
+++ b/frontend/src/app/(dashboard)/models/components/ProviderStatus.tsx
@@ -110,9 +110,9 @@ export function ProviderStatus({ providers }: ProviderStatusProps) {
         ) : null}
 
         <div className="mt-6 pt-4 border-t">
-          <a 
-            href="https://github.com/lfnovo/open-notebook/blob/main/docs/models.md" 
-            target="_blank" 
+          <a
+            href="https://github.com/lfnovo/open-notebook/blob/main/docs/features/ai-models.md"
+            target="_blank"
             rel="noopener noreferrer"
             className="text-sm text-primary hover:underline"
           >


### PR DESCRIPTION
Updated help links in DefaultModelsSection and ProviderStatus components to point to the new AI models documentation location at docs/features/ai-models.md instead of docs/models.md
