### PR TITLE
Update installation instructions for Docker Compose

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -28,7 +28,7 @@ For users who want to get started immediately:
 mkdir open-notebook && cd open-notebook
 
 # Download configuration files
-curl -O https://raw.githubusercontent.com/lfnovo/open-notebook/main/docker-compose.yml
+curl -o docker-compose.yml https://raw.githubusercontent.com/lfnovo/open-notebook/main/docker-compose.single.yml
 curl -O https://raw.githubusercontent.com/lfnovo/open-notebook/main/.env.example
 
 # Rename and configure environment


### PR DESCRIPTION
**There is no `docker-compose.yml` file in the repository.**

The closest match is `docker-compose.single.yml`.

I have changed the `curl` arguments to get this file and save it as `docker-compose.yml` so it can be recognized by Docker Compose.