### PR TITLE
fix: resolve merge conflict in SourceInsightDialog

### DIFF
--- a/frontend/src/components/source/SourceInsightDialog.tsx
+++ b/frontend/src/components/source/SourceInsightDialog.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { FileText } from 'lucide-react'
@@ -23,8 +23,10 @@ interface SourceInsightDialogProps {
   onDelete?: (insightId: string) => Promise<void>
 }
 
-export function SourceInsightDialog({ open, onOpenChange, insight }: SourceInsightDialogProps) {
+export function SourceInsightDialog({ open, onOpenChange, insight, onDelete }: SourceInsightDialogProps) {
   const { openModal } = useModalManager()
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
 
   // Ensure insight ID has 'source_insight:' prefix for API calls
   const insightIdWithPrefix = insight?.id
@@ -44,6 +46,25 @@ export function SourceInsightDialog({ open, onOpenChange, insight }: SourceInsig
       openModal('source', sourceId)
     }
   }
+
+  const handleDelete = async () => {
+    if (!insight?.id || !onDelete) return
+    setIsDeleting(true)
+    try {
+      await onDelete(insight.id)
+      onOpenChange(false)
+    } finally {
+      setIsDeleting(false)
+      setShowDeleteConfirm(false)
+    }
+  }
+
+  // Reset delete confirmation when dialog closes
+  useEffect(() => {
+    if (!open) {
+      setShowDeleteConfirm(false)
+    }
+  }, [open])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>


### PR DESCRIPTION
## Summary

Fixes a merge conflict between PRs #334 and #340 that caused the Docker build to fail.

The delete insight functionality from #334 referenced `showDeleteConfirm`, `isDeleting`, and `handleDelete` but the state definitions were lost when merging with #340's "View Source" feature.

## Changes
- Added missing `useState` hooks for `showDeleteConfirm` and `isDeleting`
- Added missing `handleDelete` function
- Added `useEffect` to reset delete confirmation when dialog closes
- Added `onDelete` to destructured props
- Removed unused `DialogFooter` import

## Test plan
- [ ] Docker build succeeds
- [ ] Delete insight functionality works in insight modal
- [ ] View Source button works in insight modal