### PR TITLE
fix(ui): optimize MutationObserver in NoteEditorDialog

### DIFF
--- a/frontend/src/app/(dashboard)/notebooks/components/NoteEditorDialog.tsx
+++ b/frontend/src/app/(dashboard)/notebooks/components/NoteEditorDialog.tsx
@@ -70,12 +70,14 @@ export function NoteEditorDialog({ open, onOpenChange, notebookId, note }: NoteE
   }, [open, note, fetchedNote, reset])
 
   useEffect(() => {
+    if (!open) return
+
     const observer = new MutationObserver(() => {
       setIsEditorFullscreen(!!document.querySelector('.w-md-editor-fullscreen'))
     })
-    observer.observe(document.body, {subtree: true, attributes: true, attributeFilter: ['class']})
+    observer.observe(document.body, { subtree: true, attributes: true, attributeFilter: ['class'] })
     return () => observer.disconnect()
-  }, [])
+  }, [open])
 
   const onSubmit = async (data: CreateNoteFormData) => {
     if (note) {


### PR DESCRIPTION
## Summary

- Only observe DOM mutations when the dialog is open
- Prevents unnecessary MutationObserver activity when dialog is closed
- Follow-up optimization to PR #305

## Related Issue

Follow-up to #305 (merged)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Tested locally with development setup
- [x] Existing tests pass
- [x] Linting passes

## Checklist

- [x] My code follows TypeScript best practices
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>