### PR TITLE
Remove debug prefixes from production error logging

### DIFF
--- a/api/routers/sources.py
+++ b/api/routers/sources.py
@@ -113,7 +113,7 @@ def parse_source_form_data(
         try:
             notebooks_list = json.loads(notebooks)
         except json.JSONDecodeError:
-            logger.error(f"DEBUG - Invalid JSON in notebooks field: {notebooks}")
+            logger.error(f"Invalid JSON in notebooks field: {notebooks}")
             raise ValueError("Invalid JSON in notebooks field")
 
     transformations_list = []
@@ -122,7 +122,7 @@ def parse_source_form_data(
             transformations_list = json.loads(transformations)
         except json.JSONDecodeError:
             logger.error(
-                f"DEBUG - Invalid JSON in transformations field: {transformations}"
+                f"Invalid JSON in transformations field: {transformations}"
             )
             raise ValueError("Invalid JSON in transformations field")
 


### PR DESCRIPTION
## Summary
Removes leftover debug prefixes from production error logging in [api/routers/sources.py](cci:7://file:///c:/Users/Soham/Desktop/PROJECTS/open-notebook/api/routers/sources.py:0:0-0:0).
## Problem
Lines 116 and 124 contain "DEBUG - " prefixes in error messages, which are development artifacts that pollute production logs.
**Before:**
```python
logger.error(f"DEBUG - Invalid JSON in notebooks field: {notebooks}")
logger.error(f"DEBUG - Invalid JSON in transformations field: {transformations}")
After:

python
logger.error(f"Invalid JSON in notebooks field: {notebooks}")
logger.error(f"Invalid JSON in transformations field: {transformations}")
Changes
Removed "DEBUG - " prefix from notebooks JSON parsing error (line 116)
Removed "DEBUG - " prefix from transformations JSON parsing error (line 124)
Testing
No functional changes. Error handling behavior remains identical - only log message formatting is affected.

Type
 Bug fix (non-breaking change)
 New feature
 Breaking change