### PR TITLE
docs: add pull_policy always to docker-compose examples

### DIFF
--- a/docs/0-START-HERE/quick-start-cloud.md
+++ b/docs/0-START-HERE/quick-start-cloud.md
@@ -32,6 +32,7 @@ services:
 
   open_notebook:
     image: lfnovo/open_notebook:v1-latest
+    pull_policy: always
     ports:
       - "8502:8502"  # Web UI
       - "5055:5055"  # API

--- a/docs/0-START-HERE/quick-start-local.md
+++ b/docs/0-START-HERE/quick-start-local.md
@@ -37,6 +37,7 @@ services:
 
   open_notebook:
     image: lfnovo/open_notebook:v1-latest-single
+    pull_policy: always
     ports:
       - "8502:8502"  # Web UI (React frontend)
       - "5055:5055"  # API (required!)

--- a/docs/0-START-HERE/quick-start-openai.md
+++ b/docs/0-START-HERE/quick-start-openai.md
@@ -29,6 +29,7 @@ services:
 
   open_notebook:
     image: lfnovo/open_notebook:v1-latest
+    pull_policy: always
     ports:
       - "8502:8502"  # Web UI
       - "5055:5055"  # API

--- a/docs/1-INSTALLATION/docker-compose.md
+++ b/docs/1-INSTALLATION/docker-compose.md
@@ -44,6 +44,7 @@ services:
 
   open_notebook:
     image: lfnovo/open_notebook:v1-latest
+    pull_policy: always
     ports:
       - "8502:8502"  # Web UI
       - "5055:5055"  # API

--- a/docs/1-INSTALLATION/single-container.md
+++ b/docs/1-INSTALLATION/single-container.md
@@ -23,6 +23,7 @@ All-in-one container setup. **Simpler than Docker Compose, but less flexible.**
 services:
   open_notebook:
     image: lfnovo/open_notebook:v1-latest-single
+    pull_policy: always
     ports:
       - "8502:8502"  # Web UI (React frontend)
       - "5055:5055"  # API

--- a/docs/5-CONFIGURATION/ollama.md
+++ b/docs/5-CONFIGURATION/ollama.md
@@ -106,6 +106,7 @@ version: '3.8'
 services:
   open-notebook:
     image: lfnovo/open_notebook:v1-latest-single
+    pull_policy: always
     ports:
       - "8502:8502"
       - "5055:5055"
@@ -458,6 +459,7 @@ export ESPERANTO_SSL_VERIFY=false
 services:
   open-notebook:
     image: lfnovo/open_notebook:v1-latest-single
+    pull_policy: always
     environment:
       - OLLAMA_API_BASE=https://ollama.local:11434
       # Option 1: Custom CA bundle

--- a/docs/5-CONFIGURATION/openai-compatible.md
+++ b/docs/5-CONFIGURATION/openai-compatible.md
@@ -159,6 +159,7 @@ services:
 
   open-notebook:
     image: lfnovo/open_notebook:v1-latest-single
+    pull_policy: always
     environment:
       - OPENAI_COMPATIBLE_BASE_URL=http://text-gen:5000/v1
     depends_on:
@@ -204,6 +205,7 @@ services:
 
   open-notebook:
     image: lfnovo/open_notebook:v1-latest-single
+    pull_policy: always
     environment:
       - OPENAI_COMPATIBLE_BASE_URL=http://vllm:8000/v1
     depends_on:

--- a/docs/5-CONFIGURATION/reverse-proxy.md
+++ b/docs/5-CONFIGURATION/reverse-proxy.md
@@ -70,6 +70,7 @@ That's it! Caddy handles HTTPS automatically.
 services:
   open-notebook:
     image: lfnovo/open_notebook:v1-latest-single
+    pull_policy: always
     environment:
       - API_URL=https://notebook.example.com
     labels:
@@ -139,6 +140,7 @@ When `API_URL` is not set, the Next.js frontend:
 services:
   open-notebook:
     image: lfnovo/open_notebook:v1-latest-single
+    pull_policy: always
     container_name: open-notebook
     environment:
       - API_URL=https://notebook.example.com
@@ -278,6 +280,7 @@ API_URL=http://192.168.1.100:5055
 services:
   open-notebook:
     image: lfnovo/open_notebook:v1-latest-single
+    pull_policy: always
     environment:
       - API_URL=http://192.168.1.100:5055
     ports:
@@ -307,6 +310,7 @@ Host the API and frontend on different subdomains:
 services:
   open-notebook:
     image: lfnovo/open_notebook:v1-latest-single
+    pull_policy: always
     environment:
       - API_URL=https://api.notebook.example.com
       - OPENAI_API_KEY=${OPENAI_API_KEY}
@@ -368,6 +372,7 @@ For complex deployments with separate frontend and API containers:
 services:
   frontend:
     image: lfnovo/open_notebook_frontend:v1-latest
+    pull_policy: always
     environment:
       - API_URL=https://notebook.example.com
     ports:
@@ -375,6 +380,7 @@ services:
 
   api:
     image: lfnovo/open_notebook_api:v1-latest
+    pull_policy: always
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
     ports:

--- a/docs/5-CONFIGURATION/security.md
+++ b/docs/5-CONFIGURATION/security.md
@@ -27,6 +27,7 @@ Protect your Open Notebook deployment with password authentication and productio
 services:
   open_notebook:
     image: lfnovo/open_notebook:v1-latest-single
+    pull_policy: always
     environment:
       - OPENAI_API_KEY=sk-...
       - OPEN_NOTEBOOK_PASSWORD=your_secure_password
@@ -186,6 +187,7 @@ async function getNotebooks() {
 services:
   open_notebook:
     image: lfnovo/open_notebook:v1-latest-single
+    pull_policy: always
     ports:
       - "127.0.0.1:8502:8502"  # Bind to localhost only
     environment:


### PR DESCRIPTION
## Summary
- Add `pull_policy: always` to all `open_notebook` service definitions in docker-compose examples
- Ensures Docker always checks for and pulls newer images when running `docker compose up`
- Updated 9 documentation files with 16 service definitions

## Test plan
- [x] Review docker-compose YAML syntax is valid
- [x] Verify pull_policy placement is correct in each example

Closes #393