### PR TITLE
fix: use persistent rocksdb storage instead of memory in docker-compose docs

### DIFF
--- a/docs/0-START-HERE/quick-start-cloud.md
+++ b/docs/0-START-HERE/quick-start-cloud.md
@@ -26,9 +26,11 @@ Create a new folder `open-notebook` and add this file:
 services:
   surrealdb:
     image: surrealdb/surrealdb:v2
-    command: start --user root --pass password --bind 0.0.0.0:8000 memory
+    command: start --user root --pass password --bind 0.0.0.0:8000 rocksdb:/mydata/mydatabase.db
     ports:
       - "8000:8000"
+    volumes:
+      - ./surreal_data:/mydata
 
   open_notebook:
     image: lfnovo/open_notebook:v1-latest

--- a/docs/0-START-HERE/quick-start-local.md
+++ b/docs/0-START-HERE/quick-start-local.md
@@ -31,9 +31,11 @@ Create a new folder `open-notebook-local` and add this file:
 services:
   surrealdb:
     image: surrealdb/surrealdb:v2
-    command: start --user root --pass password --bind 0.0.0.0:8000 memory
+    command: start --user root --pass password --bind 0.0.0.0:8000 rocksdb:/mydata/mydatabase.db
     ports:
       - "8000:8000"
+    volumes:
+      - ./surreal_data:/mydata
 
   open_notebook:
     image: lfnovo/open_notebook:v1-latest-single
@@ -68,6 +70,7 @@ services:
       # Optional: set GPU support if available
       - OLLAMA_NUM_GPU=0
     restart: always
+
 ```
 
 **That's it!** No API keys, no secrets, completely private.

--- a/docs/0-START-HERE/quick-start-openai.md
+++ b/docs/0-START-HERE/quick-start-openai.md
@@ -23,9 +23,11 @@ Create a new folder `open-notebook` and add this file:
 services:
   surrealdb:
     image: surrealdb/surrealdb:v2
-    command: start --user root --pass password --bind 0.0.0.0:8000 memory
+    command: start --user root --pass password --bind 0.0.0.0:8000 rocksdb:/mydata/mydatabase.db
     ports:
       - "8000:8000"
+    volumes:
+      - ./surreal_data:/mydata
 
   open_notebook:
     image: lfnovo/open_notebook:v1-latest
@@ -48,6 +50,7 @@ services:
     depends_on:
       - surrealdb
     restart: always
+
 ```
 
 **Edit the file:**

--- a/docs/1-INSTALLATION/docker-compose.md
+++ b/docs/1-INSTALLATION/docker-compose.md
@@ -36,11 +36,11 @@ Create a folder `open-notebook` and add this file:
 services:
   surrealdb:
     image: surrealdb/surrealdb:v2
-    command: start --user root --pass password --bind 0.0.0.0:8000 memory
+    command: start --user root --pass password --bind 0.0.0.0:8000 rocksdb:/mydata/mydatabase.db
     ports:
       - "8000:8000"
     volumes:
-      - surreal_data:/mydata
+      - ./surreal_data:/mydata
 
   open_notebook:
     image: lfnovo/open_notebook:v1-latest
@@ -66,8 +66,6 @@ services:
       - surrealdb
     restart: always
 
-volumes:
-  surreal_data:
 ```
 
 **Edit the file:**


### PR DESCRIPTION
## Summary
- Changed SurrealDB storage from `memory` to `rocksdb:/mydata/mydatabase.db` in all docker-compose documentation
- Added bind mount `./surreal_data:/mydata` for data persistence
- Users' data will now survive container restarts

## Files Changed
- `docs/1-INSTALLATION/docker-compose.md`
- `docs/0-START-HERE/quick-start-openai.md`
- `docs/0-START-HERE/quick-start-cloud.md`
- `docs/0-START-HERE/quick-start-local.md`

## Test plan
- [ ] Verify docker-compose examples work with new configuration
- [ ] Confirm data persists after `docker compose down && docker compose up`

Fixes #398