### PR TITLE
fix: increase Next.js proxy body size limit for file uploads

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -4,6 +4,13 @@ const nextConfig: NextConfig = {
   // Enable standalone output for optimized Docker deployment
   output: "standalone",
 
+  // Experimental features
+  experimental: {
+    // Increase proxy body size limit for file uploads (default is 10MB)
+    // This allows larger files to be uploaded through the /api/* rewrite proxy to FastAPI
+    proxyClientMaxBodySize: '100mb',
+  },
+
   // API Rewrites: Proxy /api/* requests to FastAPI backend
   // This simplifies reverse proxy configuration - users only need to proxy to port 8502
   // Next.js handles internal routing to the API backend on port 5055


### PR DESCRIPTION
## Summary
- Added `experimental.proxyClientMaxBodySize: '100mb'` to Next.js config
- This increases the proxy body buffer limit from 10MB (default) to 100MB
- Allows larger files (MP3s, PDFs, etc.) to be uploaded through the `/api/*` rewrite to FastAPI

## Root Cause
Next.js has a default 10MB body size limit for requests going through rewrites/proxy. When users upload files larger than 10MB, Next.js logs a warning and only buffers the first 10MB, which can cause upload failures.

## Test plan
- [ ] Upload a file larger than 10MB (e.g., 14MB MP3)
- [ ] Verify the upload completes successfully

Fixes #361