### PR TITLE
ci: remove single-container build from dev workflow

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -12,15 +12,6 @@ on:
       - '.github/workflows/claude*.yml'
   workflow_dispatch:
     inputs:
-      dockerfile:
-        description: 'Dockerfile to test'
-        required: true
-        default: 'both'
-        type: choice
-        options:
-          - both
-          - regular
-          - single
       platform:
         description: 'Platform to build'
         required: true
@@ -43,7 +34,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Extract version from pyproject.toml
         id: version
         run: |
@@ -51,10 +42,9 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Extracted version: $VERSION"
 
-  test-build-regular:
+  test-build:
     needs: extract-version
     runs-on: ubuntu-latest
-    if: github.event.inputs.dockerfile == 'regular' || github.event.inputs.dockerfile == 'both' || github.event_name != 'workflow_dispatch'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -66,18 +56,18 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache-dev
-          key: ${{ runner.os }}-buildx-dev-regular-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-dev-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-dev-regular-
+            ${{ runner.os }}-buildx-dev-
 
-      - name: Build regular image (test only)
+      - name: Build image (test only)
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
           platforms: ${{ github.event.inputs.platform || 'linux/amd64' }}
           push: false
-          tags: ${{ env.IMAGE_NAME }}:${{ needs.extract-version.outputs.version }}-dev-regular
+          tags: ${{ env.IMAGE_NAME }}:${{ needs.extract-version.outputs.version }}-dev
           cache-from: type=local,src=/tmp/.buildx-cache-dev
           cache-to: type=local,dest=/tmp/.buildx-cache-dev-new,mode=max
 
@@ -86,43 +76,8 @@ jobs:
           rm -rf /tmp/.buildx-cache-dev
           mv /tmp/.buildx-cache-dev-new /tmp/.buildx-cache-dev
 
-  test-build-single:
-    needs: extract-version
-    runs-on: ubuntu-latest
-    if: github.event.inputs.dockerfile == 'single' || github.event.inputs.dockerfile == 'both' || github.event_name != 'workflow_dispatch'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache-dev-single
-          key: ${{ runner.os }}-buildx-dev-single-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-dev-single-
-
-      - name: Build single-container image (test only)
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./Dockerfile.single
-          platforms: ${{ github.event.inputs.platform || 'linux/amd64' }}
-          push: false
-          tags: ${{ env.IMAGE_NAME }}:${{ needs.extract-version.outputs.version }}-dev-single
-          cache-from: type=local,src=/tmp/.buildx-cache-dev-single
-          cache-to: type=local,dest=/tmp/.buildx-cache-dev-single-new,mode=max
-
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache-dev-single
-          mv /tmp/.buildx-cache-dev-single-new /tmp/.buildx-cache-dev-single
-
   summary:
-    needs: [extract-version, test-build-regular, test-build-single]
+    needs: [extract-version, test-build]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -131,26 +86,17 @@ jobs:
           echo "## Development Build Summary" >> $GITHUB_STEP_SUMMARY
           echo "**Version:** ${{ needs.extract-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "**Platform:** ${{ github.event.inputs.platform || 'linux/amd64' }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Dockerfile:** ${{ github.event.inputs.dockerfile || 'both' }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Results:" >> $GITHUB_STEP_SUMMARY
 
-          if [[ "${{ needs.test-build-regular.result }}" == "success" ]]; then
-            echo "✅ **Regular Dockerfile:** Build successful" >> $GITHUB_STEP_SUMMARY
-          elif [[ "${{ needs.test-build-regular.result }}" == "skipped" ]]; then
-            echo "⏭️ **Regular Dockerfile:** Skipped" >> $GITHUB_STEP_SUMMARY
+          if [[ "${{ needs.test-build.result }}" == "success" ]]; then
+            echo "✅ **Dockerfile:** Build successful" >> $GITHUB_STEP_SUMMARY
+          elif [[ "${{ needs.test-build.result }}" == "skipped" ]]; then
+            echo "⏭️ **Dockerfile:** Skipped" >> $GITHUB_STEP_SUMMARY
           else
-            echo "❌ **Regular Dockerfile:** Build failed" >> $GITHUB_STEP_SUMMARY
+            echo "❌ **Dockerfile:** Build failed" >> $GITHUB_STEP_SUMMARY
           fi
-          
-          if [[ "${{ needs.test-build-single.result }}" == "success" ]]; then
-            echo "✅ **Single Dockerfile:** Build successful" >> $GITHUB_STEP_SUMMARY
-          elif [[ "${{ needs.test-build-single.result }}" == "skipped" ]]; then
-            echo "⏭️ **Single Dockerfile:** Skipped" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "❌ **Single Dockerfile:** Build failed" >> $GITHUB_STEP_SUMMARY
-          fi
-          
+
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Notes:" >> $GITHUB_STEP_SUMMARY
           echo "- This is a development build (no images pushed to registry)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Removes the single-container Docker build from the development workflow
- Cuts PR build time roughly in half by only testing the multi-container Dockerfile
- Single-container build is still available in the production `build-and-release` workflow

## Changes
- Removed `test-build-single` job
- Removed `dockerfile` input option (no longer needed with single build)
- Simplified summary output

## Test plan
- [ ] Verify the workflow runs successfully on this PR
- [ ] Confirm only one Docker build job runs instead of two