### PR TITLE
fix: prevent duplicate Claude Code workflow runs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,11 +14,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Run for fork PRs (via pull_request_target) OR same-repo PRs (via pull_request), but not both
+    if: |
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

Fixes duplicate workflow runs when both `pull_request` and `pull_request_target` triggers fire for the same PR.

## Problem

With both triggers enabled, each PR gets TWO workflow runs:
1. `pull_request` event run
2. `pull_request_target` event run  

This causes:
- Wasted CI resources
- Confusing duplicate checks on PRs  
- Potential conflicts between the two runs

## Solution

Added conditional logic to ensure only one workflow runs per PR:

```yaml
if: |
  (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) ||
  (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
```

This means:
- **Fork PRs** (external contributors): Only `pull_request_target` runs (has OIDC tokens)
- **Same-repo PRs** (internal branches): Only `pull_request` runs (faster, uses PR's workflow version)

## Testing

Can be verified on:
- Fork PRs like #414 (should only have one `pull_request_target` run)
- Same-repo PRs (should only have one `pull_request` run)

## Related

- Closes #414 workflow issue
- Follow-up to #416