### PR TITLE
fix: delete uploaded files when sources are removed

### DIFF
--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -5,13 +5,17 @@ This test suite focuses on validation logic, business rules, and data structures
 that can be tested without database mocking.
 """
 
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from pydantic import ValidationError
 
 from open_notebook.ai.models import ModelManager
 from open_notebook.domain.base import RecordModel
 from open_notebook.domain.content_settings import ContentSettings
-from open_notebook.domain.notebook import Note, Notebook, Source
+from open_notebook.domain.notebook import Asset, Note, Notebook, Source
 from open_notebook.domain.transformation import Transformation
 from open_notebook.exceptions import InvalidInputError
 from open_notebook.podcasts.models import EpisodeProfile, SpeakerProfile
@@ -118,6 +122,82 @@ class TestSourceDomain:
         source3 = Source(id="source:123", title="Test", command="command:456")
         save_data = source3._prepare_save_data()
         assert "command" in save_data
+
+    @pytest.mark.asyncio
+    async def test_source_delete_cleans_up_file(self):
+        """Test that deleting a source removes the associated file."""
+        # Create a temporary file
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as tmp_file:
+            tmp_file.write(b"Test content")
+            tmp_path = Path(tmp_file.name)
+
+        try:
+            # Create source with file asset
+            source = Source(
+                id="source:test_delete",
+                title="Test Source",
+                asset=Asset(file_path=str(tmp_path))
+            )
+
+            # Verify file exists
+            assert tmp_path.exists()
+
+            # Mock the parent delete method to avoid database operations
+            with patch.object(Source.__bases__[0], 'delete', new_callable=AsyncMock) as mock_delete:
+                mock_delete.return_value = True
+
+                # Delete the source
+                result = await source.delete()
+
+                # Verify parent delete was called
+                mock_delete.assert_called_once()
+                assert result is True
+
+            # Verify file was deleted
+            assert not tmp_path.exists()
+
+        finally:
+            # Cleanup in case test fails
+            if tmp_path.exists():
+                tmp_path.unlink()
+
+    @pytest.mark.asyncio
+    async def test_source_delete_without_file(self):
+        """Test that deleting a source without a file doesn't fail."""
+        # Create source without file asset
+        source = Source(
+            id="source:test_no_file",
+            title="Test Source",
+            asset=None
+        )
+
+        # Mock the parent delete method
+        with patch.object(Source.__bases__[0], 'delete', new_callable=AsyncMock) as mock_delete:
+            mock_delete.return_value = True
+
+            # Delete should complete without error
+            result = await source.delete()
+            assert result is True
+            mock_delete.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_source_delete_continues_on_file_error(self):
+        """Test that source deletion continues even if file deletion fails."""
+        # Create source with non-existent file
+        source = Source(
+            id="source:test_missing_file",
+            title="Test Source",
+            asset=Asset(file_path="/nonexistent/path/file.txt")
+        )
+
+        # Mock the parent delete method
+        with patch.object(Source.__bases__[0], 'delete', new_callable=AsyncMock) as mock_delete:
+            mock_delete.return_value = True
+
+            # Delete should complete even though file doesn't exist
+            result = await source.delete()
+            assert result is True
+            mock_delete.assert_called_once()
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Fixes #420 

Previously, uploaded files were not deleted when sources were removed from the system. This caused:
- Accumulation of orphaned files consuming disk space
- Potential privacy/security concerns with deleted source files remaining accessible on the filesystem

## Changes

- Modified `Source.delete()` to clean up associated uploaded files before database deletion
- Added graceful error handling to continue with database deletion even if file cleanup fails
- Added comprehensive test coverage for file cleanup scenarios

## Test Coverage

Added three new test cases:
- File cleanup on successful source deletion
- Deletion without files (URL-based sources)  
- Graceful handling when file doesn't exist or cleanup fails

All existing tests continue to pass (14/14 domain tests passing).