### PR TITLE
chore: bump version to 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.2] - 2026-01-15
+
+### Performance
+- Improved source listing speed by 20-30x (#436, closes #351)
+  - Added database indexes on `source` field for `source_insight` and `source_embedding` tables
+  - Use SurrealDB `FETCH` clause for command status instead of N async calls
+
 ## [1.5.1] - 2026-01-15
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "open-notebook"
-version = "1.5.1"
+version = "1.5.2"
 description = "An open source implementation of a research assistant, inspired by Google Notebook LM"
 authors = [
     {name = "Luis Novo", email = "lfnovo@gmail.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -2375,7 +2375,7 @@ wheels = [
 
 [[package]]
 name = "open-notebook"
-version = "1.5.1"
+version = "1.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "ai-prompter" },


### PR DESCRIPTION
## Summary

Version bump to 1.5.2 for release, documenting the source listing performance improvements from #436.

### Changes
- Bump version from 1.5.1 to 1.5.2
- Add CHANGELOG entry for performance improvements (closes #351)

## Test plan

- [ ] Verify version in pyproject.toml is 1.5.2
- [ ] Verify CHANGELOG has entry for 1.5.2