### PR TITLE
fix: correct embedded flag always showing Yes

### DIFF
--- a/api/routers/sources.py
+++ b/api/routers/sources.py
@@ -185,7 +185,7 @@ async def get_sources(
             query = f"""
                 SELECT id, asset, created, title, updated, topics, command,
                 (SELECT VALUE count() FROM source_insight WHERE source = $parent.id GROUP ALL)[0].count OR 0 AS insights_count,
-                ((SELECT VALUE id FROM source_embedding WHERE source = $parent.id LIMIT 1)) != NONE AS embedded
+                (SELECT VALUE id FROM source_embedding WHERE source = $parent.id LIMIT 1) != [] AS embedded
                 FROM (select value in from reference where out=$notebook_id)
                 {order_clause}
                 LIMIT $limit START $offset
@@ -204,7 +204,7 @@ async def get_sources(
             query = f"""
                 SELECT id, asset, created, title, updated, topics, command,
                 (SELECT VALUE count() FROM source_insight WHERE source = $parent.id GROUP ALL)[0].count OR 0 AS insights_count,
-                ((SELECT VALUE id FROM source_embedding WHERE source = $parent.id LIMIT 1)) != NONE AS embedded
+                (SELECT VALUE id FROM source_embedding WHERE source = $parent.id LIMIT 1) != [] AS embedded
                 FROM source
                 {order_clause}
                 LIMIT $limit START $offset


### PR DESCRIPTION
## Summary

Fixes #397 - Sources show "Embedded: Yes" even when they're not embedded.

### Root Cause

The SurrealQL query was checking:
```sql
((SELECT VALUE id FROM source_embedding WHERE source = $parent.id LIMIT 1)) != NONE AS embedded
```

When there are no matching records, `SELECT VALUE ... LIMIT 1` returns an **empty array `[]`**, not `NONE`. The comparison `[] != NONE` evaluates to `true`, causing all sources to incorrectly show as embedded.

### Fix

Changed the comparison to check against empty array:
```sql
(SELECT VALUE id FROM source_embedding WHERE source = $parent.id LIMIT 1) != [] AS embedded
```

## Test plan

- [ ] Add a source without an embedding model configured
- [ ] Verify it shows "Embedded: No" in the sources list
- [ ] Configure embedding model and embed the source
- [ ] Verify it now shows "Embedded: Yes"