### PR TITLE
feat: add centralized HTTP/HTTPS proxy configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,6 +90,27 @@ API_URL=http://localhost:5055
 # Set this to protect your Open Notebook instance with a password (for public hosting)
 # OPEN_NOTEBOOK_PASSWORD=
 
+# HTTP/HTTPS PROXY
+# Route all external HTTP requests through a proxy server
+# Useful for corporate/firewalled environments
+#
+# Affects:
+# - AI provider API calls (OpenAI, Anthropic, Google, etc.)
+# - Content extraction from URLs (web scraping, YouTube)
+# - Podcast generation (LLM and TTS calls)
+#
+# Format: http://[user:pass@]host:port or https://[user:pass@]host:port
+#
+# Examples:
+# - Basic proxy: OPEN_NOTEBOOK_PROXY=http://proxy.corp.com:8080
+# - Authenticated: OPEN_NOTEBOOK_PROXY=http://user:password@proxy.corp.com:8080
+# - HTTPS proxy: OPEN_NOTEBOOK_PROXY=https://secure-proxy.corp.com:443
+#
+# NOTE: If your proxy intercepts HTTPS traffic (e.g., mitmproxy, corporate SSL inspection),
+# you may need to configure SSL verification. See ESPERANTO_SSL_VERIFY and ESPERANTO_SSL_CA_BUNDLE above.
+#
+# OPEN_NOTEBOOK_PROXY=
+
 # OPENAI
 # OPENAI_API_KEY=
 

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ full:
 
 
 api:
-	uv run run_api.py
+	uv run --env-file .env run_api.py
 
 # === Worker Management ===
 .PHONY: worker worker-start worker-stop worker-restart

--- a/commands/CLAUDE.md
+++ b/commands/CLAUDE.md
@@ -14,7 +14,7 @@
 ### Other Commands
 
 - **`process_source_command`**: Ingests content through `source_graph`, creates embeddings (optional), and generates insights. Retries on transaction conflicts (exp. jitter, max 5×).
-- **`generate_podcast_command`**: Creates podcasts via `podcast-creator` library using stored episode/speaker profiles.
+- **`generate_podcast_command`**: Creates podcasts via `podcast-creator` library using stored episode/speaker profiles. **Automatically passes proxy** from `config.PROXY` if set.
 - **`process_text_command`** (example): Test fixture for text operations (uppercase, lowercase, reverse, word_count).
 - **`analyze_data_command`** (example): Test fixture for numeric aggregations.
 

--- a/commands/podcast_commands.py
+++ b/commands/podcast_commands.py
@@ -6,7 +6,7 @@ from loguru import logger
 from pydantic import BaseModel
 from surreal_commands import CommandInput, CommandOutput, command
 
-from open_notebook.config import DATA_FOLDER
+from open_notebook.config import DATA_FOLDER, PROXY
 from open_notebook.database.repository import ensure_record_id, repo_query
 from open_notebook.podcasts.models import EpisodeProfile, PodcastEpisode, SpeakerProfile
 
@@ -135,6 +135,7 @@ async def generate_podcast_command(
             output_dir=str(output_dir),
             speaker_config=speaker_profile.name,
             episode_profile=episode_profile.name,
+            proxy=PROXY,
         )
 
         episode.audio_file = (

--- a/docs/5-CONFIGURATION/environment-reference.md
+++ b/docs/5-CONFIGURATION/environment-reference.md
@@ -223,6 +223,39 @@ For self-hosted LLMs, LM Studio, or OpenAI-compatible endpoints:
 
 ---
 
+## Network / Proxy
+
+| Variable | Required? | Default | Description |
+|----------|-----------|---------|-------------|
+| `OPEN_NOTEBOOK_PROXY` | No | None | HTTP/HTTPS proxy URL for all external requests |
+
+Route all outbound HTTP requests through a proxy server. Useful for corporate/firewalled environments.
+
+**Affects:**
+- AI provider API calls (OpenAI, Anthropic, Google, Groq, etc.)
+- Content extraction from URLs (web scraping, YouTube transcripts)
+- Podcast generation (LLM and TTS provider calls)
+
+**Format:** `http://[user:pass@]host:port` or `https://[user:pass@]host:port`
+
+**Examples:**
+```bash
+# Basic proxy
+OPEN_NOTEBOOK_PROXY=http://proxy.corp.com:8080
+
+# Authenticated proxy
+OPEN_NOTEBOOK_PROXY=http://user:password@proxy.corp.com:8080
+
+# HTTPS proxy
+OPEN_NOTEBOOK_PROXY=https://secure-proxy.corp.com:443
+```
+
+**Notes:**
+- Proxy credentials are automatically redacted from logs
+- If your proxy intercepts HTTPS traffic (corporate SSL inspection, mitmproxy, etc.), you'll get `SSL: CERTIFICATE_VERIFY_FAILED` errors. Configure `ESPERANTO_SSL_CA_BUNDLE` with your proxy's CA certificate, or set `ESPERANTO_SSL_VERIFY=false` for testing (not recommended for production)
+
+---
+
 ## Debugging & Monitoring
 
 | Variable | Required? | Default | Description |
@@ -260,6 +293,12 @@ SURREAL_PASSWORD=secure_password
 ```
 OPENAI_COMPATIBLE_BASE_URL=http://localhost:1234/v1
 API_URL=https://mynotebook.example.com
+```
+
+### Corporate Environment (Behind Proxy)
+```
+OPENAI_API_KEY=sk-proj-...
+OPEN_NOTEBOOK_PROXY=http://proxy.corp.com:8080
 ```
 
 ### High-Performance Deployment

--- a/open_notebook/CLAUDE.md
+++ b/open_notebook/CLAUDE.md
@@ -73,8 +73,18 @@ All components communicate through async/await patterns and use Pydantic for val
 
 ### Configuration & Exceptions
 
-- **`config.py`**: Paths for data folder, uploads, LangGraph checkpoints, and tiktoken cache. Auto-creates directories.
+- **`config.py`**: Paths for data folder, uploads, LangGraph checkpoints, and tiktoken cache. Auto-creates directories. Also reads `OPEN_NOTEBOOK_PROXY` for HTTP/HTTPS proxy configuration.
 - **`exceptions.py`**: Hierarchy of OpenNotebookError subclasses for database, file, network, authentication, and rate-limit failures.
+
+### Proxy Configuration
+
+All external HTTP requests (AI providers, content extraction, podcast generation) can be routed through a proxy by setting `OPEN_NOTEBOOK_PROXY` environment variable. The proxy URL is:
+- Read once at startup in `config.py` as `PROXY` constant
+- Injected into AI model calls via `ModelManager.get_model()` (passed to Esperanto)
+- Injected into content extraction via `source.py` graph (passed to content-core)
+- Passed to podcast generation in `podcast_commands.py` (passed to podcast-creator)
+
+**Note**: If using an HTTPS-intercepting proxy (corporate SSL inspection, mitmproxy), configure `ESPERANTO_SSL_CA_BUNDLE` with the proxy's CA certificate, or set `ESPERANTO_SSL_VERIFY=false` for testing.
 
 ## Data Flow: Content Ingestion
 

--- a/open_notebook/ai/CLAUDE.md
+++ b/open_notebook/ai/CLAUDE.md
@@ -31,11 +31,12 @@ All models use Esperanto library as provider abstraction (OpenAI, Anthropic, Goo
 
 #### ModelManager
 - Stateless factory for instantiating AI models
-- `get_model(model_id)`: Retrieves Model by ID, creates via AIFactory.create_* based on type
+- `get_model(model_id)`: Retrieves Model by ID, creates via AIFactory.create_* based on type. **Automatically injects proxy configuration** from `config.PROXY` if set.
 - `get_defaults()`: Fetches DefaultModels configuration
 - `get_default_model(model_type)`: Smart lookup (e.g., "chat" → default_chat_model, "transformation" → default_transformation_model with fallback to chat)
 - `get_speech_to_text()`, `get_text_to_speech()`, `get_embedding_model()`: Type-specific convenience methods with assertions
 - **Global instance**: `model_manager` singleton exported for use throughout app
+- **Proxy support**: When `OPEN_NOTEBOOK_PROXY` env var is set, all AI provider calls are routed through the proxy
 
 ### provision.py
 
@@ -75,6 +76,7 @@ All models use Esperanto library as provider abstraction (OpenAI, Anthropic, Goo
 - **Esperanto caching**: Actual model instances cached by Esperanto (not by ModelManager); ModelManager stateless
 - **Fallback chain specificity**: "transformation" type falls back to default_chat_model if not explicitly set (convention-based)
 - **kwargs passed through**: provision_langchain_model() passes kwargs to AIFactory but doesn't validate what's accepted
+- **Proxy injection**: Proxy from `config.PROXY` is injected in `get_model()` before kwargs, so explicit `proxy=` in kwargs would override the global setting
 
 ## How to Extend
 

--- a/open_notebook/ai/models.py
+++ b/open_notebook/ai/models.py
@@ -9,6 +9,7 @@ from esperanto import (
 )
 from loguru import logger
 
+from open_notebook.config import PROXY
 from open_notebook.database.repository import ensure_record_id, repo_query
 from open_notebook.domain.base import ObjectModel, RecordModel
 
@@ -86,6 +87,10 @@ class ModelManager:
             "text_to_speech",
         ]:
             raise ValueError(f"Invalid model type: {model.type}")
+
+        # Inject proxy configuration if set
+        if PROXY:
+            kwargs["proxy"] = PROXY
 
         # Create model based on type (Esperanto will cache the instance)
         if model.type == "language":

--- a/open_notebook/config.py
+++ b/open_notebook/config.py
@@ -15,3 +15,7 @@ os.makedirs(UPLOADS_FOLDER, exist_ok=True)
 # TIKTOKEN CACHE FOLDER
 TIKTOKEN_CACHE_DIR = f"{DATA_FOLDER}/tiktoken-cache"
 os.makedirs(TIKTOKEN_CACHE_DIR, exist_ok=True)
+
+# PROXY CONFIGURATION
+# Optional HTTP/HTTPS proxy for all external requests (AI providers, content extraction, etc.)
+PROXY = os.getenv("OPEN_NOTEBOOK_PROXY")

--- a/open_notebook/graphs/CLAUDE.md
+++ b/open_notebook/graphs/CLAUDE.md
@@ -19,7 +19,7 @@ LangGraph-based workflow orchestration for content processing, chat interactions
 - **Prompt templating**: `ai_prompter.Prompter` with Jinja2 templates referenced by path ("chat/system", "ask/entry", etc.)
 - **Model provisioning via context**: Config dict passed to node via `RunnableConfig`; defaults fall back to state overrides
 - **Checkpointing**: `chat.py` and `source_chat.py` use SqliteSaver for message history (LangGraph's built-in persistence)
-- **Content extraction**: `source.py` uses content-core library with provider/model from DefaultModels; URLs and files both supported
+- **Content extraction**: `source.py` uses content-core library with provider/model from DefaultModels; URLs and files both supported. **Automatically injects proxy** from `config.PROXY` into content_state if set.
 
 ## Quirks & Edge Cases
 

--- a/open_notebook/graphs/source.py
+++ b/open_notebook/graphs/source.py
@@ -10,6 +10,7 @@ from loguru import logger
 from typing_extensions import Annotated, TypedDict
 
 from open_notebook.ai.models import Model, ModelManager
+from open_notebook.config import PROXY
 from open_notebook.domain.content_settings import ContentSettings
 from open_notebook.domain.notebook import Asset, Source
 from open_notebook.domain.transformation import Transformation
@@ -58,6 +59,10 @@ async def content_process(state: SourceState) -> dict:
         content_settings.default_content_processing_engine_doc or "auto"
     )
     content_state["output_format"] = "markdown"
+
+    # Inject proxy configuration if set
+    if PROXY:
+        content_state["proxy"] = PROXY
 
     # Add speech-to-text model configuration from Default Models
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "ai-prompter>=0.3,<1",
     "esperanto>=2.17.2,<3",
     "surrealdb>=1.0.4",
-    "podcast-creator>=0.7.0,<1",
+    "podcast-creator>=0.8,<1",
     "surreal-commands>=1.3.0,<2",
     "numpy>=2.4.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2464,7 +2464,7 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.1" },
     { name = "numpy", specifier = ">=2.4.1" },
-    { name = "podcast-creator", specifier = ">=0.7.0,<1" },
+    { name = "podcast-creator", specifier = ">=0.8,<1" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.1" },
     { name = "pydantic", specifier = ">=2.9.2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
@@ -2814,14 +2814,13 @@ wheels = [
 
 [[package]]
 name = "podcast-creator"
-version = "0.7.3"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ai-prompter" },
     { name = "click" },
     { name = "content-core" },
     { name = "esperanto" },
-    { name = "langchain-openai" },
     { name = "langgraph" },
     { name = "loguru" },
     { name = "moviepy" },
@@ -2831,9 +2830,9 @@ dependencies = [
     { name = "requests" },
     { name = "tiktoken" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/ed/d2586b7420d5afa227817e7cb0c63eaef6a825012271e1ec32beb353c30b/podcast_creator-0.7.3.tar.gz", hash = "sha256:5b8a9db1b5ba7d0e413579bb24b68a8166e7526579ff77dc748d4d7d82ab388d", size = 443918, upload-time = "2025-10-25T13:45:04.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/57/c0af369633a55c8a005f2614f429d638ef46c2f5869baf878f865f946948/podcast_creator-0.8.0.tar.gz", hash = "sha256:bedc487c60ad0ea6e95076002f2d2582e264a470bd0e5fb4caa9e358ca8522c2", size = 470411, upload-time = "2026-01-27T17:04:42.763Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/00/47c3157298519b084d1210d90e0d492f7942469c8f5304a088626482888f/podcast_creator-0.7.3-py3-none-any.whl", hash = "sha256:b0545bf942426ac9ab5f9579a02f0471d905e328b83f95d49840b9e7eeac1a51", size = 73995, upload-time = "2025-10-25T13:45:03.969Z" },
+    { url = "https://files.pythonhosted.org/packages/71/0d/86d8e1c85488545af2a1b65603f23e93cc0b8a75bcde0cb51922f01dac6d/podcast_creator-0.8.0-py3-none-any.whl", hash = "sha256:0454d927dfcb5e6aa40ce64acb7f1f6dd737a56a7133b0d52c25a55e59f4a411", size = 76017, upload-time = "2026-01-27T17:04:43.929Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds `OPEN_NOTEBOOK_PROXY` environment variable to route all external HTTP requests through a proxy server. Useful for corporate/firewalled environments.

### Changes

- **config.py**: Added `PROXY` constant reading from `OPEN_NOTEBOOK_PROXY`
- **ai/models.py**: Inject proxy into all AIFactory calls via ModelManager
- **graphs/source.py**: Inject proxy into content-core content_state
- **commands/podcast_commands.py**: Pass proxy to podcast-creator
- **docs**: Updated `.env.example` and `environment-reference.md`
- **CLAUDE.md files**: Documented proxy architecture in relevant module docs
- **pyproject.toml**: Bumped podcast-creator to >=0.8 (proxy support)

### Proxy affects

- AI provider API calls (OpenAI, Anthropic, Google, Groq, etc.)
- Content extraction from URLs (web scraping, YouTube transcripts)
- Podcast generation (LLM and TTS provider calls)

### Testing

Tested manually with mitmproxy:
- AI model calls work through proxy
- Authenticated proxy (user:pass) format supported

### Known Limitation

`NO_PROXY` environment variable is not respected when proxy is explicitly configured. This affects users who want to use a proxy for external services but bypass it for internal services (e.g., local Ollama). See [esperanto#74](https://github.com/lfnovo/esperanto/issues/74).

### Specs

- [spec.md](./specs/proxy-configuration/spec.md)
- [architecture.md](./specs/proxy-configuration/architecture.md)
- [plan.md](./specs/proxy-configuration/plan.md)