### PR TITLE
feat(security): Add non-root user to runtime stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,4 +107,9 @@ RUN mkdir -p /var/log/supervisor
 #
 # Example: docker run -e API_URL=https://your-domain.com/api ...
 
+# Add non-root user for security best practices
+RUN adduser --disabled-password --gecos "" --uid 65532 appuser && \
+    chown -R appuser:appuser /app /var/log/supervisor
+USER appuser
+
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]


### PR DESCRIPTION
This PR adds a non-root user to the Docker runtime stage,
following Docker security best practices and CIS benchmarks.

## Summary

The user is created with UID 65532 and the working directory
is properly owned before switching to the non-root user.

## Changes

- Create `appuser` with UID 65532 using adduser
- Chown `/app` and `/var/log/supervisor` directories
- Switch to appuser before entrypoint

## Security Impact

This prevents the container process from running as root,
reducing the security impact of potential container escapes.
Following CIS Docker Benchmark 1.0.0 - Ensure containers are running as a non-root user.

## Testing

Built and tested locally with `docker build`. Container starts successfully as non-root user.