### PR TITLE
fix(api): initialize file_path before try block

### DIFF
--- a/api/routers/sources.py
+++ b/api/routers/sources.py
@@ -285,6 +285,9 @@ async def create_source(
     """Create a new source with support for both JSON and multipart form data."""
     source_data, upload_file = form_data
 
+    # Initialize file_path before try block so exception handlers can reference it
+    file_path = None
+
     try:
         # Verify all specified notebooks exist (backward compatibility support)
         for notebook_id in source_data.notebooks or []:
@@ -295,7 +298,6 @@ async def create_source(
                 )
 
         # Handle file upload if provided
-        file_path = None
         if upload_file and source_data.type == "upload":
             try:
                 file_path = await save_uploaded_file(upload_file)


### PR DESCRIPTION
This PR fixes a potential UnboundLocalError in the API router
by ensuring file_path is initialized before the try block.

## Issue

In the `create_source` endpoint (api/routers/sources.py), `file_path`
was initialized inside the try block. If an exception occurred before
this initialization, exception handlers that reference `file_path`
would crash with `UnboundLocalError`.

## Fix

- Initialize `file_path = None` before the try block
- Add explanatory comment for future maintainers
- Remove duplicate initialization inside the try block

This ensures exception handlers can safely reference `file_path`
without causing runtime errors.

## Impact

- Prevents potential runtime crash in error handling path
- Follows Python best practices for variable initialization
- No behavior changes for successful execution path

## Testing

- Verified exception handler path no longer crashes
- Confirmed file cleanup works correctly in error cases