### PR TITLE
fix: Docker networking and permissions documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,9 @@ COPY . /app
 ENV UV_NO_SYNC=1
 ENV VIRTUAL_ENV=/app/.venv
 
+# Bind Next.js to all interfaces (required for Docker networking and reverse proxies)
+ENV HOSTNAME=0.0.0.0
+
 # Copy built frontend from builder stage
 COPY --from=builder /app/frontend/.next/standalone /app/frontend/
 COPY --from=builder /app/frontend/.next/static /app/frontend/.next/static

--- a/Dockerfile.single
+++ b/Dockerfile.single
@@ -59,6 +59,9 @@ COPY --from=frontend-builder /app/frontend/.next/standalone /app/frontend/
 COPY --from=frontend-builder /app/frontend/.next/static /app/frontend/.next/static
 COPY --from=frontend-builder /app/frontend/public /app/frontend/public
 
+# Bind Next.js to all interfaces (required for Docker networking and reverse proxies)
+ENV HOSTNAME=0.0.0.0
+
 # Setup directories and permissions
 RUN mkdir -p /app/data /mydata
 

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ full:
 api:
 	uv run --env-file .env run_api.py
 
-# === Worker Management ===
+
 .PHONY: worker worker-start worker-stop worker-restart
 
 worker: worker-start

--- a/docs/1-INSTALLATION/docker-compose.md
+++ b/docs/1-INSTALLATION/docker-compose.md
@@ -37,6 +37,7 @@ services:
   surrealdb:
     image: surrealdb/surrealdb:v2
     command: start --user root --pass password --bind 0.0.0.0:8000 rocksdb:/mydata/mydatabase.db
+    user: root  # Required for bind mounts on Linux (SurrealDB runs as non-root by default)
     ports:
       - "8000:8000"
     volumes:
@@ -282,6 +283,29 @@ docker compose logs surrealdb
 ```
 
 Reset database:
+```bash
+docker compose down -v
+docker compose up -d
+```
+
+### Database Permission Denied (Linux)
+
+If you see `Permission denied` or `Failed to create RocksDB directory` in SurrealDB logs:
+
+```bash
+docker compose logs surrealdb | grep -i permission
+```
+
+This happens because SurrealDB runs as a non-root user but Docker creates bind mount directories as root. Add `user: root` to the surrealdb service:
+
+```yaml
+surrealdb:
+  image: surrealdb/surrealdb:v2
+  user: root  # Fix for Linux bind mount permissions
+  # ... rest of config
+```
+
+Then restart:
 ```bash
 docker compose down -v
 docker compose up -d

--- a/docs/5-CONFIGURATION/environment-reference.md
+++ b/docs/5-CONFIGURATION/environment-reference.md
@@ -12,6 +12,7 @@ Comprehensive list of all environment variables available in Open Notebook.
 | `INTERNAL_API_URL` | No | http://localhost:5055 | Internal API URL for Next.js server-side proxying |
 | `API_CLIENT_TIMEOUT` | No | 300 | Client timeout in seconds (how long to wait for API response) |
 | `OPEN_NOTEBOOK_PASSWORD` | No | None | Password to protect Open Notebook instance |
+| `HOSTNAME` | No | `0.0.0.0` (in Docker) | Network interface for Next.js to bind to. Default `0.0.0.0` ensures accessibility from reverse proxies |
 
 ---
 

--- a/docs/5-CONFIGURATION/reverse-proxy.md
+++ b/docs/5-CONFIGURATION/reverse-proxy.md
@@ -108,6 +108,8 @@ API_URL=https://your-domain.com
 
 **Important**: Set `API_URL` to your public URL (with https://).
 
+**Note on HOSTNAME**: The Docker images set `HOSTNAME=0.0.0.0` by default, which ensures Next.js binds to all interfaces and is accessible from reverse proxies. You typically don't need to set this manually.
+
 ---
 
 ## Understanding API_URL


### PR DESCRIPTION
## Summary

Fixes three common Docker deployment issues reported by users:

- **#483** - Linux users need `extra_hosts` for `host.docker.internal` to resolve when connecting to host Ollama
- **#485** - Next.js binds to container hostname instead of `0.0.0.0`, breaking reverse proxy setups (Traefik, nginx)
- **#409** - SurrealDB permission denied on Linux when using bind mounts

## Changes

### Issue #483 - Linux `host.docker.internal`
- Added Linux-specific warning in Ollama docs "Scenario 2" section with `extra_hosts` example
- Added `extra_hosts` fix as first item in "Docker-Specific Troubleshooting" section

### Issue #485 - Next.js HOSTNAME binding  
- Added `ENV HOSTNAME=0.0.0.0` as default in both `Dockerfile` and `Dockerfile.single`
- Updated environment reference to document the HOSTNAME variable
- Updated reverse proxy docs to note this is now set by default

### Issue #409 - SurrealDB permissions
- Added `user: root` to the docker-compose example with explanatory comment
- Added "Database Permission Denied (Linux)" troubleshooting section

## Test plan

- [ ] Verify Dockerfiles build correctly with new ENV
- [ ] Review documentation changes for accuracy
- [ ] Test docker-compose example on Linux

Fixes #483, fixes #485, fixes #409