### PR TITLE
fix: async insight creation to prevent transaction conflicts

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -395,6 +395,16 @@ class SourceInsightResponse(BaseModel):
     updated: str
 
 
+class InsightCreationResponse(BaseModel):
+    """Response for async insight creation."""
+
+    status: Literal["pending"] = "pending"
+    message: str = "Insight generation started"
+    source_id: str
+    transformation_id: str
+    command_id: Optional[str] = None
+
+
 class SaveAsNoteRequest(BaseModel):
     notebook_id: Optional[str] = Field(None, description="Notebook ID to add note to")
 

--- a/commands/CLAUDE.md
+++ b/commands/CLAUDE.md
@@ -9,11 +9,13 @@
 - **`embed_note_command`**: Embeds a single note using unified embedding pipeline with content-type aware processing. Uses MARKDOWN content type detection. Retry: 5 attempts, exponential jitter 1-60s.
 - **`embed_insight_command`**: Embeds a single source insight. Uses MARKDOWN content type. Retry: 5 attempts, exponential jitter 1-60s.
 - **`embed_source_command`**: Embeds a source by chunking full_text with content-type aware splitters (HTML, Markdown, plain), then batch embedding all chunks. Uses single Esperanto API call. Retry: 5 attempts, exponential jitter 1-60s.
+- **`create_insight_command`**: Creates a source insight with automatic retry on transaction conflicts. Creates the DB record, then submits `embed_insight` command (fire-and-forget). Retry: 5 attempts, exponential jitter 1-60s. Used by `Source.add_insight()`.
 - **`rebuild_embeddings_command`**: Submits individual embed_* commands for all sources/notes/insights. Returns immediately; actual embedding happens async. No retry (coordinator only).
 
 ### Other Commands
 
-- **`process_source_command`**: Ingests content through `source_graph`, creates embeddings (optional), and generates insights. Retries on transaction conflicts (exp. jitter, max 5×).
+- **`process_source_command`**: Ingests content through `source_graph`, creates embeddings (optional), and generates insights. Retries on transaction conflicts (exp. jitter, max 15×, 1-120s).
+- **`run_transformation_command`**: Runs a transformation on an existing source to generate an insight. Executes the transformation graph (LLM call) then creates insight via `create_insight_command`. Used by `POST /sources/{id}/insights` API endpoint. Retry: 5 attempts, exponential jitter 1-60s.
 - **`generate_podcast_command`**: Creates podcasts via `podcast-creator` library using stored episode/speaker profiles.
 - **`process_text_command`** (example): Test fixture for text operations (uppercase, lowercase, reverse, word_count).
 - **`analyze_data_command`** (example): Test fixture for numeric aggregations.

--- a/frontend/src/app/(dashboard)/notebooks/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/notebooks/[id]/page.tsx
@@ -58,16 +58,21 @@ export default function NotebookPage() {
     notes: {}
   })
 
-  // Initialize default selections when sources/notes load
+  // Initialize and update selections when sources load or change
   useEffect(() => {
     if (sources && sources.length > 0) {
       setContextSelections(prev => {
         const newSourceSelections = { ...prev.sources }
         sources.forEach(source => {
-          // Only set default if not already set
-          if (!(source.id in newSourceSelections)) {
-            // Default to 'insights' if has insights, otherwise 'full'
-            newSourceSelections[source.id] = source.insights_count > 0 ? 'insights' : 'full'
+          const currentMode = newSourceSelections[source.id]
+          const hasInsights = source.insights_count > 0
+
+          if (currentMode === undefined) {
+            // Initial setup - default based on insights availability
+            newSourceSelections[source.id] = hasInsights ? 'insights' : 'full'
+          } else if (currentMode === 'full' && hasInsights) {
+            // Source gained insights while in 'full' mode - auto-switch to 'insights'
+            newSourceSelections[source.id] = 'insights'
           }
         })
         return { ...prev, sources: newSourceSelections }

--- a/frontend/src/lib/api/insights.ts
+++ b/frontend/src/lib/api/insights.ts
@@ -13,6 +13,21 @@ export interface CreateSourceInsightRequest {
   transformation_id: string
 }
 
+export interface InsightCreationResponse {
+  status: 'pending'
+  message: string
+  source_id: string
+  transformation_id: string
+  command_id?: string
+}
+
+export interface CommandJobStatusResponse {
+  job_id: string
+  status: string
+  result?: Record<string, unknown>
+  error_message?: string
+}
+
 export const insightsApi = {
   listForSource: async (sourceId: string) => {
     const response = await apiClient.get<SourceInsightResponse[]>(`/sources/${sourceId}/insights`)
@@ -25,7 +40,7 @@ export const insightsApi = {
   },
 
   create: async (sourceId: string, data: CreateSourceInsightRequest) => {
-    const response = await apiClient.post<SourceInsightResponse>(
+    const response = await apiClient.post<InsightCreationResponse>(
       `/sources/${sourceId}/insights`,
       data
     )
@@ -34,5 +49,46 @@ export const insightsApi = {
 
   delete: async (insightId: string) => {
     await apiClient.delete(`/insights/${insightId}`)
+  },
+
+  getCommandStatus: async (commandId: string) => {
+    const response = await apiClient.get<CommandJobStatusResponse>(
+      `/commands/jobs/${commandId}`
+    )
+    return response.data
+  },
+
+  /**
+   * Poll command status until completed or failed.
+   * Returns true if completed successfully, false if failed.
+   */
+  waitForCommand: async (
+    commandId: string,
+    options?: { maxAttempts?: number; intervalMs?: number }
+  ): Promise<boolean> => {
+    const maxAttempts = options?.maxAttempts ?? 60 // Default 60 attempts
+    const intervalMs = options?.intervalMs ?? 2000 // Default 2 seconds
+
+    for (let i = 0; i < maxAttempts; i++) {
+      try {
+        const status = await insightsApi.getCommandStatus(commandId)
+        if (status.status === 'completed') {
+          return true
+        }
+        if (status.status === 'failed' || status.status === 'canceled') {
+          console.error('Command failed:', status.error_message)
+          return false
+        }
+        // Still running, wait and retry
+        await new Promise(resolve => setTimeout(resolve, intervalMs))
+      } catch (error) {
+        console.error('Error checking command status:', error)
+        // Continue polling on error
+        await new Promise(resolve => setTimeout(resolve, intervalMs))
+      }
+    }
+    // Timeout
+    console.warn('Command polling timed out')
+    return false
   }
 }

--- a/frontend/src/lib/locales/en-US/index.ts
+++ b/frontend/src/lib/locales/en-US/index.ts
@@ -357,6 +357,7 @@ export const enUS = {
     viewInsight: "View Insight",
     deleteInsight: "Delete Insight",
     deleteInsightConfirm: "Are you sure you want to delete this insight? This action cannot be undone.",
+    insightGenerationStarted: "Insight generation started. It will appear shortly.",
     deleteNoteConfirm: 'Are you sure you want to delete this note? This action cannot be undone.',
     editNote: 'Edit note',
     createNote: 'Create note',

--- a/frontend/src/lib/locales/ja-JP/index.ts
+++ b/frontend/src/lib/locales/ja-JP/index.ts
@@ -357,6 +357,7 @@ export const jaJP = {
     viewInsight: "インサイトを表示",
     deleteInsight: "インサイトを削除",
     deleteInsightConfirm: "このインサイトを削除しますか？この操作は元に戻せません。",
+    insightGenerationStarted: "インサイトの生成が開始されました。まもなく表示されます。",
     deleteNoteConfirm: 'このノートを削除しますか？この操作は元に戻せません。',
     editNote: 'ノートを編集',
     createNote: 'ノートを作成',

--- a/frontend/src/lib/locales/pt-BR/index.ts
+++ b/frontend/src/lib/locales/pt-BR/index.ts
@@ -357,6 +357,7 @@ export const ptBR = {
     viewInsight: "Ver Insight",
     deleteInsight: "Excluir Insight",
     deleteInsightConfirm: "Tem certeza que deseja excluir este insight? Esta ação não pode ser desfeita.",
+    insightGenerationStarted: "Geração de insight iniciada. Aparecerá em breve.",
     deleteNoteConfirm: "Tem certeza que deseja excluir esta nota? Esta ação não pode ser desfeita.",
     editNote: "Editar nota",
     createNote: "Criar nota",

--- a/frontend/src/lib/locales/zh-CN/index.ts
+++ b/frontend/src/lib/locales/zh-CN/index.ts
@@ -363,6 +363,7 @@ export const zhCN = {
     noNotebooksAvailable: "暂无可用笔记本",
     deleteInsight: "删除见解",
     deleteInsightConfirm: "确定要删除此见解吗？此操作无法撤销。",
+    insightGenerationStarted: "见解生成已开始，稍后将显示。",
     notEmbeddedAlert: "内容未嵌入向量",
     notEmbeddedDesc: "此内容尚未为了向量搜索进行嵌入。嵌入可以启用高级搜索功能并更好地发现内容。",
     openOnYoutube: "在 YouTube 上打开",

--- a/frontend/src/lib/locales/zh-TW/index.ts
+++ b/frontend/src/lib/locales/zh-TW/index.ts
@@ -363,6 +363,7 @@ export const zhTW = {
     noNotebooksAvailable: "暫無可用筆記本",
     deleteInsight: "刪除見解",
     deleteInsightConfirm: "確定要刪除此見解嗎？此操作無法撤銷。",
+    insightGenerationStarted: "見解生成已開始，稍後將顯示。",
     notEmbeddedAlert: "內容未嵌入向量",
     notEmbeddedDesc: "此內容尚未為了向量搜尋進行嵌入。嵌入可以啟用進階搜尋功能並更好地發現內容。",
     openOnYoutube: "在 YouTube 上開啟",

--- a/open_notebook/domain/CLAUDE.md
+++ b/open_notebook/domain/CLAUDE.md
@@ -32,7 +32,7 @@ Two base classes support different persistence patterns: **ObjectModel** (mutabl
   - `vectorize()`: Submit async embedding job (returns command_id, fire-and-forget)
   - `get_status()`, `get_processing_progress()`: Track job via surreal_commands
   - `get_context()`: Returns summary for LLM context
-  - `add_insight()`: Generate and store insights with embeddings
+  - `add_insight()`: Submit async insight creation via `create_insight_command` (fire-and-forget, returns command_id)
 
 - **Note**: Standalone or linked notes
   - `save()`: Submits `embed_note` command after save (fire-and-forget)
@@ -80,7 +80,7 @@ Two base classes support different persistence patterns: **ObjectModel** (mutabl
 - **Auto-embedding behavior**:
   - `Note.save()` → auto-submits `embed_note` command
   - `Source.save()` → does NOT auto-submit (must call `vectorize()` explicitly)
-  - `Source.add_insight()` → auto-submits `embed_insight` command
+  - `Source.add_insight()` → submits `create_insight_command` which handles DB insert + `embed_insight` command (all fire-and-forget)
 - **Relationship strings**: Must match SurrealDB schema (reference, artifact, refers_to)
 
 ## How to Add New Model


### PR DESCRIPTION
## Summary

- Migrates insight creation to the command system with automatic retry logic to prevent SurrealDB transaction conflicts during batch imports
- Makes insight generation fully asynchronous so the UI remains responsive even with slow LLMs
- Auto-updates notebook page when insights are created on source page

## Changes

### Backend
- Add `create_insight_command` with 5-attempt retry logic for transaction conflicts
- Add `run_transformation_command` for async transformation execution (LLM call + insight creation)
- Make `Source.add_insight()` fire-and-forget (returns command_id immediately)
- Update `POST /sources/{id}/insights` to return 202 Accepted with command_id
- Add `InsightCreationResponse` model with status and command tracking

### Frontend
- Poll command status until complete, then refresh insights list
- Invalidate sources cache so notebook page updates with new insights_count
- Auto-switch notebook page icon from "full content" to "insights" when source gains insights
- Add i18n keys for "Insight generation started" message (all 5 locales)

## Test Plan

- [ ] Create insight on source page → should return immediately with toast, insight appears when done
- [ ] Batch import sources with transformations → no transaction conflict errors
- [ ] Notebook page icon updates when source gains insights
- [ ] Works with slow local LLMs (polls up to 4 minutes)

Related to #489