### PR TITLE
fix: use sync get_state() for SqliteSaver compatibility

### DIFF
--- a/open_notebook/utils/graph_utils.py
+++ b/open_notebook/utils/graph_utils.py
@@ -1,11 +1,16 @@
+import asyncio
+
 from langchain_core.runnables import RunnableConfig
 from loguru import logger
+
 
 async def get_session_message_count(graph, session_id: str) -> int:
     """Get message count from LangGraph state, returns 0 on error."""
     try:
-        thread_state = await graph.aget_state( # async version
-            config=RunnableConfig(configurable={"thread_id": session_id})
+        # Use sync get_state() in a thread (SqliteSaver doesn't support async)
+        thread_state = await asyncio.to_thread(
+            graph.get_state,
+            config=RunnableConfig(configurable={"thread_id": session_id}),
         )
         if (
             thread_state


### PR DESCRIPTION
## Summary

- Fix async/sync mismatch when calling `get_state()` on graphs using `SqliteSaver`
- Use `asyncio.to_thread()` to run sync `get_state()` from async context

## Problem

PR #430 introduced `await graph.aget_state()` calls to retrieve message counts, but the chat graphs use synchronous `SqliteSaver` which doesn't support async methods.

Error:
```
The SqliteSaver does not support async methods. Consider using AsyncSqliteSaver instead.
```

## Solution

Instead of switching to `AsyncSqliteSaver` (which would break the existing sync `graph.invoke()` calls), this fix uses `asyncio.to_thread()` to run the sync `get_state()` method in a threadpool, maintaining compatibility with both:
- Existing sync graph invocations (`.invoke()`)
- Async FastAPI endpoints that need to fetch session state

## Test plan

- [x] All 98 existing tests pass
- [x] Linter passes

Closes #509