### PR TITLE
feat: add environment variables for chunk size configuration

### DIFF
--- a/open_notebook/utils/CLAUDE.md
+++ b/open_notebook/utils/CLAUDE.md
@@ -18,6 +18,30 @@ Provides cross-cutting concerns: building LLM context from sources/insights, con
 
 Each utility is stateless and can be imported independently.
 
+## Configuration
+
+### Chunking Configuration (chunking.py)
+
+The chunking behavior can be configured via environment variables:
+
+- **OPEN_NOTEBOOK_CHUNK_SIZE**: Maximum chunk size in characters (default: 1200)
+  - Minimum: 100 characters
+  - Warnings: Values > 8192 characters or invalid values
+  - Use case: Smaller models (e.g., mxbai-embed-large with limited context window)
+
+- **OPEN_NOTEBOOK_CHUNK_OVERLAP**: Overlap between chunks in characters (default: 15% of CHUNK_SIZE)
+  - Must be: >= 0 and < CHUNK_SIZE
+  - Warnings: Invalid values or values >= CHUNK_SIZE
+  - Use case: Control how much context is shared between adjacent chunks
+
+Example for models with small context windows:
+```bash
+export OPEN_NOTEBOOK_CHUNK_SIZE=512
+export OPEN_NOTEBOOK_CHUNK_OVERLAP=50
+```
+
+Note: Changes require restart of the application.
+
 ## Component Catalog
 
 ### context_builder.py
@@ -39,8 +63,8 @@ Each utility is stateless and can be imported independently.
 
 ### chunking.py
 - **ContentType**: Enum (HTML, MARKDOWN, PLAIN)
-- **CHUNK_SIZE**: constant
-- **CHUNK_OVERLAP**: constant
+- **CHUNK_SIZE**: Configurable via `OPEN_NOTEBOOK_CHUNK_SIZE` env var (default: 1200)
+- **CHUNK_OVERLAP**: Configurable via `OPEN_NOTEBOOK_CHUNK_OVERLAP` env var (default: 15% of CHUNK_SIZE)
 - **detect_content_type_from_extension(file_path)**: Detect type from file extension
 - **detect_content_type_from_heuristics(text)**: Detect type from content patterns (returns type + confidence)
 - **detect_content_type(text, file_path)**: Combined detection (extension primary, heuristics fallback)
@@ -125,7 +149,7 @@ Each utility is stateless and can be imported independently.
 
 1. **Add new context source type**: Create fetch method in ContextBuilder; update ContextConfig.sources dict
 2. **Add content type**: Add to ContentType enum; create splitter getter; update chunk_text()
-3. **Change chunk size**: Modify CHUNK_SIZE and CHUNK_OVERLAP constants in chunking.py
+3. **Change chunk size**: Set OPEN_NOTEBOOK_CHUNK_SIZE and OPEN_NOTEBOOK_CHUNK_OVERLAP environment variables
 4. **Add text preprocessing**: Add new function to text_utils (e.g., remove_urls, extract_keywords)
 5. **Change tokenization**: Replace tiktoken with alternative library in token_utils; update all calls
 6. **Add context filtering**: Extend ContextConfig with filter_by_date, filter_by_topic fields


### PR DESCRIPTION
## Summary

This PR implements the feature requested in #510 to enable CHUNK_SIZE overwrite via environment variables, supporting embedding models with smaller context windows like mxbai-embed-large.

## Changes

- **Added environment variable support** in :
  - : Configurable chunk size (default: 1200, minimum: 100)
  - : Configurable overlap (default: 15% of chunk size)

- **Added validation and warnings**:
  - Validates values are valid integers
  - Warns if chunk size < 100 (too small) or > 8192 (very large)
  - Ensures overlap is >= 0 and < chunk size
  - Falls back to sensible defaults with warnings for invalid inputs

- **Updated documentation** in :
  - Added Configuration section with environment variable reference
  - Updated component catalog to reflect new env var-based configuration

## Usage

Users can now configure chunking behavior by setting environment variables:

```bash
# For mxbai-embed-large with limited context window
export OPEN_NOTEBOOK_CHUNK_SIZE=512
export OPEN_NOTEBOOK_CHUNK_OVERLAP=50
```

## Backward Compatibility

✅ **No breaking changes** - The default behavior remains exactly the same (CHUNK_SIZE=1200, CHUNK_OVERLAP=180). Only users who explicitly set the environment variables will see different behavior.

## Testing

- All 43 existing tests pass (30 chunking + 13 embedding tests)
- Manual verification completed for:
  - Default values (1200/180)
  - Custom values (e.g., 512/50)
  - Validation warnings for invalid/edge case values

## Closes

Closes #510