### PR TITLE
fix: prevent note editor from expanding beyond dialog bounds

### DIFF
--- a/frontend/src/app/(dashboard)/notebooks/components/NoteEditorDialog.tsx
+++ b/frontend/src/app/(dashboard)/notebooks/components/NoteEditorDialog.tsx
@@ -162,7 +162,7 @@ export function NoteEditorDialog({ open, onOpenChange, notebookId, note }: NoteE
                       height={420}
                       placeholder={t.sources.writeNotePlaceholder}
                       className={cn(
-                          "w-full h-full min-h-[420px] [&_.w-md-editor]:!static [&_.w-md-editor]:!w-full [&_.w-md-editor]:!h-full",
+                          "w-full h-full min-h-[420px] max-h-[500px] overflow-hidden [&_.w-md-editor]:!static [&_.w-md-editor]:!w-full [&_.w-md-editor]:!h-full [&_.w-md-editor-content]:overflow-y-auto",
                           !isEditorFullscreen && "rounded-md border"
                       )}
                     />


### PR DESCRIPTION
## Summary
Fixes an issue where the note editor textarea would expand indefinitely as you type, eventually pushing the save button out of view.

## Changes
- Added `max-h-[500px]` constraint to the MarkdownEditor component
- Added `overflow-hidden` to prevent container expansion
- Made internal editor content scrollable with `overflow-y-auto`

## Before
The editor would grow vertically without limits, causing the dialog to expand and hide the save button below the fold.

## After  
The editor maintains a maximum height of 500px and scrolls internally, keeping the save button always visible at the bottom of the dialog.

## Testing
- Open the note editor dialog
- Type or paste a large amount of content
- Verify the editor scrolls internally instead of expanding
- Confirm the save button remains visible and accessible