### PR TITLE
chore: bump version to 1.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "open-notebook"
-version = "1.7.0-rc1"
+version = "1.7.0"
 description = "An open source implementation of a research assistant, inspired by Google Notebook LM"
 authors = [
     {name = "Luis Novo", email = "lfnovo@gmail.com"}


### PR DESCRIPTION
Version bump from 1.7.0-rc1 to 1.7.0 for official release.

This is a quick version bump to prepare for the official v1.7.0 release after successful RC testing.