### PR TITLE
docs: fix docker container names in local setup guides

### DIFF
--- a/docs/0-START-HERE/quick-start-local.md
+++ b/docs/0-START-HERE/quick-start-local.md
@@ -96,13 +96,13 @@ Ollama needs at least one language model. Pick one:
 
 ```bash
 # Fastest & smallest (recommended for testing)
-docker exec open_notebook-ollama-1 ollama pull mistral
+docker exec open-notebook-local-ollama-1 ollama pull mistral
 
 # OR: Better quality but slower
-docker exec open_notebook-ollama-1 ollama pull neural-chat
+docker exec open-notebook-local-ollama-1 ollama pull neural-chat
 
 # OR: Even better quality, more VRAM needed
-docker exec open_notebook-ollama-1 ollama pull llama2
+docker exec open-notebook-local-ollama-1 ollama pull llama2
 ```
 
 This downloads the model (will take 1-5 minutes depending on your internet).
@@ -224,7 +224,7 @@ docker compose up -d
 Check if GPU is available:
 ```bash
 # Show available GPUs
-docker exec open_notebook-ollama-1 ollama ps
+docker exec open-notebook-local-ollama-1 ollama ps
 
 # Enable GPU in docker-compose.yml:
 # - OLLAMA_NUM_GPU=1
@@ -236,10 +236,10 @@ Then restart: `docker compose restart ollama`
 
 ```bash
 # List available models
-docker exec open_notebook-ollama-1 ollama list
+docker exec open-notebook-local-ollama-1 ollama list
 
 # Pull additional model
-docker exec open_notebook-ollama-1 ollama pull neural-chat
+docker exec open-notebook-local-ollama-1 ollama pull neural-chat
 ```
 
 ---

--- a/docs/1-INSTALLATION/docker-compose.md
+++ b/docs/1-INSTALLATION/docker-compose.md
@@ -174,7 +174,7 @@ volumes:
 Then restart and pull a model:
 ```bash
 docker compose restart
-docker exec open_notebook-ollama-1 ollama pull mistral
+docker exec open-notebook-local-ollama-1 ollama pull mistral
 ```
 
 Configure Ollama in the Settings UI:


### PR DESCRIPTION
## Summary
- Fix incorrect container names in `quick-start-local.md` (6 occurrences) and `docker-compose.md` (1 occurrence)
- Docker Compose v2 derives container names from the directory name using dashes, so the correct name is `open-notebook-local-ollama-1`, not `open_notebook-ollama-1`

## Test plan
- [x] Verified all `docker exec` commands reference the correct container name matching the `open-notebook-local` directory name

Fixes #575