### PR TITLE
Release 1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.1] - 2026-02-14
+
+### Added
+- French (fr-FR) language support (#581)
+- CI test workflow and improved i18n validation (#580)
+- Expose embed `command_id` in note API responses (#545)
+
+### Fixed
+- ElevenLabs TTS credential passthrough via Esperanto update (#578)
+- Handle empty/whitespace source content without retry loop (#576)
+- Increase transformation `max_tokens` and update Esperanto dep (#568)
+- Turn the embedding field into optional (#557)
+
+### Docs
+- Fix docker container names in local setup guides (#577)
+
+### Dependencies
+- Bump langchain-core from 1.2.7 to 1.2.11 (#564)
+- Bump cryptography from 46.0.3 to 46.0.5 (#563)
+
 ## [1.7.0] - 2026-02-10
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,4 +218,4 @@ See dedicated CLAUDE.md files for detailed guidance:
 
 ---
 
-**Last Updated**: January 2026 | **Project Version**: 1.2.4+
+**Last Updated**: February 2026 | **Project Version**: 1.7.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "open-notebook"
-version = "1.7.0"
+version = "1.7.1"
 description = "An open source implementation of a research assistant, inspired by Google Notebook LM"
 authors = [
     {name = "Luis Novo", email = "lfnovo@gmail.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -2095,7 +2095,7 @@ wheels = [
 
 [[package]]
 name = "open-notebook"
-version = "1.7.0"
+version = "1.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "ai-prompter" },


### PR DESCRIPTION
## Summary

Patch release bumping version to 1.7.1 with all changes merged since v1.7.0.

### What's included

**Added**
- French (fr-FR) language support (#581)
- CI test workflow and improved i18n validation (#580)
- Expose embed `command_id` in note API responses (#545)

**Fixed**
- ElevenLabs TTS credential passthrough via Esperanto update (#578)
- Handle empty/whitespace source content without retry loop (#576)
- Increase transformation `max_tokens` and update Esperanto dep (#568)
- Turn the embedding field into optional (#557)

**Docs**
- Fix docker container names in local setup guides (#577)

**Dependencies**
- Bump langchain-core from 1.2.7 to 1.2.11 (#564)
- Bump cryptography from 46.0.3 to 46.0.5 (#563)

## Changes
- Bump version in `pyproject.toml` to 1.7.1
- Update `CHANGELOG.md` with all changes since 1.7.0
- Update `CLAUDE.md` project version reference
- Regenerate `uv.lock`