### PR TITLE
fix: embedding batch sizing and 413 error classification (1.7.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.4] - 2026-02-18
+
+### Fixed
+- Embedding large documents (3MB+) fails with 413 Payload Too Large (#594)
+- `generate_embeddings()` now batches texts in groups of 50 with per-batch retry, preventing provider payload limits from being exceeded
+- 413 errors now classified with user-friendly message in error classifier
+- Misleading "Created 0 embedded chunks" log in `process_source_command` — embedding is fire-and-forget, so the count was always 0; now logs "embedding submitted" instead
+
 ## [1.7.3] - 2026-02-17
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,4 +218,4 @@ See dedicated CLAUDE.md files for detailed guidance:
 
 ---
 
-**Last Updated**: February 2026 | **Project Version**: 1.7.2
+**Last Updated**: February 2026 | **Project Version**: 1.7.4

--- a/commands/embedding_commands.py
+++ b/commands/embedding_commands.py
@@ -328,7 +328,7 @@ async def embed_source_command(input_data: EmbedSourceInput) -> EmbedSourceOutpu
     2. DELETE existing source_embedding records for this source
     3. Detect content type from file path or content
     4. Chunk text using appropriate splitter
-    5. Generate embeddings for all chunks in a single API call
+    5. Generate embeddings for all chunks in batches
     6. Bulk INSERT source_embedding records
 
     Retry Strategy:
@@ -377,7 +377,7 @@ async def embed_source_command(input_data: EmbedSourceInput) -> EmbedSourceOutpu
         if total_chunks == 0:
             raise ValueError("No chunks created after splitting text")
 
-        # 5. Generate embeddings for all chunks in single API call
+        # 5. Generate embeddings for all chunks in batches
         cmd_id = get_command_id(input_data)
         logger.debug(f"Generating embeddings for {total_chunks} chunks")
         embeddings = await generate_embeddings(chunks, command_id=cmd_id)

--- a/commands/source_commands.py
+++ b/commands/source_commands.py
@@ -115,24 +115,25 @@ async def process_source_command(
         processed_source = result["source"]
 
         # 4. Gather processing results (notebook associations handled by source_graph)
-        embedded_chunks = (
-            await processed_source.get_embedded_chunks() if input_data.embed else 0
-        )
+        # Note: embedding is fire-and-forget (async job), so we can't query the
+        # count here — it hasn't completed yet. The embed_source_command logs
+        # the actual count when it finishes.
         insights_list = await processed_source.get_insights()
         insights_created = len(insights_list)
 
         processing_time = time.time() - start_time
+        embed_status = "submitted" if input_data.embed else "skipped"
         logger.info(
             f"Successfully processed source: {processed_source.id} in {processing_time:.2f}s"
         )
         logger.info(
-            f"Created {insights_created} insights and {embedded_chunks} embedded chunks"
+            f"Created {insights_created} insights, embedding {embed_status}"
         )
 
         return SourceProcessingOutput(
             success=True,
             source_id=str(processed_source.id),
-            embedded_chunks=embedded_chunks,
+            embedded_chunks=0,
             insights_created=insights_created,
             processing_time=processing_time,
         )

--- a/open_notebook/domain/notebook.py
+++ b/open_notebook/domain/notebook.py
@@ -416,7 +416,7 @@ class Source(ObjectModel):
         pool exhaustion when processing large documents. The embed_source command:
         1. Detects content type from file path
         2. Chunks text using content-type aware splitter
-        3. Generates all embeddings in a single API call
+        3. Generates all embeddings in batches
         4. Bulk inserts source_embedding records
 
         Returns:

--- a/open_notebook/utils/CLAUDE.md
+++ b/open_notebook/utils/CLAUDE.md
@@ -78,7 +78,7 @@ Note: Changes require restart of the application.
 
 ### embedding.py
 - **mean_pool_embeddings(embeddings)**: Combine multiple embeddings via normalized mean pooling
-- **generate_embeddings(texts)**: Batch embedding via single Esperanto API call
+- **generate_embeddings(texts)**: Batch embedding with automatic batching (default 50 texts per batch) and per-batch retry
 - **generate_embedding(text, content_type, file_path)**: Unified embedding with automatic chunking + mean pooling
 
 **Key behavior**:

--- a/open_notebook/utils/error_classifier.py
+++ b/open_notebook/utils/error_classifier.py
@@ -54,6 +54,12 @@ _CLASSIFICATION_RULES: list[tuple[list[str], type[OpenNotebookError], str | None
         ExternalServiceError,
         "Content too large for the selected model. Try using a smaller selection or a model with a larger context window.",
     ),
+    # Payload too large errors
+    (
+        ["413", "payload too large", "request entity too large"],
+        ExternalServiceError,
+        "The request payload is too large for the AI provider. Try reducing the content size or using a different model.",
+    ),
     # Provider availability errors
     (
         ["500", "502", "503", "service unavailable", "overloaded", "internal server error"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "open-notebook"
-version = "1.7.3"
+version = "1.7.4"
 description = "An open source implementation of a research assistant, inspired by Google Notebook LM"
 authors = [
     {name = "Luis Novo", email = "lfnovo@gmail.com"}

--- a/uv.lock
+++ b/uv.lock
@@ -2095,7 +2095,7 @@ wheels = [
 
 [[package]]
 name = "open-notebook"
-version = "1.7.3"
+version = "1.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "ai-prompter" },


### PR DESCRIPTION
## Summary

- **Batch embedding**: `generate_embeddings()` now splits texts into batches of 50 with per-batch retry (3 attempts, 2s delay), preventing 413 Payload Too Large errors when embedding large documents (3MB+, ~3,000+ chunks)
- **413 error classification**: Added classification rule so 413 errors show a user-friendly message instead of opaque error
- **Fixed misleading log**: Removed premature `get_embedded_chunks()` call in `process_source_command` — embedding is fire-and-forget, so the count was always 0. Now logs "embedding submitted/skipped" instead

Closes #594

## Test plan

- [x] All 69 existing + new tests pass (`test_embedding.py`, `test_chunking.py`, `test_utils.py`)
- [x] Manual test: uploaded 3.8MB markdown document (~4,880 chunks), embedded successfully in ~161s with no 413 errors
- [x] New tests: batching (120 texts -> 3 batches), retry on transient failure, retry exhaustion, 413 classification