### PR TITLE
docs: add missing SURREAL_NAMESPACE and SURREAL_DATABASE env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ services:
       - SURREAL_URL=ws://surrealdb:8000/rpc
       - SURREAL_USER=root
       - SURREAL_PASSWORD=root
+      - SURREAL_NAMESPACE=open_notebook
+      - SURREAL_DATABASE=open_notebook
     volumes:
       - ./notebook_data:/app/data
     depends_on:

--- a/docs/1-INSTALLATION/docker-compose.md
+++ b/docs/1-INSTALLATION/docker-compose.md
@@ -194,6 +194,8 @@ Configure Ollama in the Settings UI:
 | `SURREAL_URL` | Database connection | `ws://surrealdb:8000/rpc` |
 | `SURREAL_USER` | Database user | `root` |
 | `SURREAL_PASSWORD` | Database password | `root` |
+| `SURREAL_NAMESPACE` | Database namespace | `open_notebook` |
+| `SURREAL_DATABASE` | Database name | `open_notebook` |
 | `API_URL` | API external URL | `http://localhost:5055` |
 
 See [Environment Reference](../5-CONFIGURATION/environment-reference.md) for complete list.

--- a/docs/1-INSTALLATION/single-container.md
+++ b/docs/1-INSTALLATION/single-container.md
@@ -107,6 +107,8 @@ heroku config:set OPEN_NOTEBOOK_ENCRYPTION_KEY=your-secret-key
 | `SURREAL_URL` | Database | `ws://localhost:8000/rpc` |
 | `SURREAL_USER` | DB user | `root` |
 | `SURREAL_PASSWORD` | DB password | `password` |
+| `SURREAL_NAMESPACE` | DB namespace | `open_notebook` |
+| `SURREAL_DATABASE` | DB name | `open_notebook` |
 | `API_URL` | External URL (for remote access) | `https://myapp.example.com` |
 
 AI provider API keys are configured via the **Settings → API Keys** UI after deployment.


### PR DESCRIPTION
## Summary
- Add missing `SURREAL_NAMESPACE` and `SURREAL_DATABASE` environment variables to the inline docker-compose example in README
- Add these variables to the environment variable reference tables in `docs/1-INSTALLATION/docker-compose.md` and `docs/1-INSTALLATION/single-container.md`

Users who copied the README example instead of downloading the actual `docker-compose.yml` were getting connection failures because these two required variables were missing.

Closes #592