### PR TITLE
Fix #572: [Bug]:  Third-Party TTS Providers Voice ID Configuration Not

### DIFF
--- a/frontend/src/components/podcasts/forms/SpeakerProfileFormDialog.tsx
+++ b/frontend/src/components/podcasts/forms/SpeakerProfileFormDialog.tsx
@@ -334,9 +334,10 @@ export function SpeakerProfileFormDialog({
                     <Input
                       id={`speaker-voice-${index}`}
                       {...register(`speakers.${index}.voice_id` as const)}
-                      placeholder="voice_123"
+                      placeholder={t.podcasts.voiceIdPlaceholder}
                       autoComplete="off"
                     />
+                    <p className="text-xs text-muted-foreground">{t.podcasts.voiceIdHint}</p>
                     {errors.speakers?.[index]?.voice_id ? (
                       <p className="text-xs text-red-600">
                         {errors.speakers[index]?.voice_id?.message}

--- a/frontend/src/lib/locales/en-US/index.ts
+++ b/frontend/src/lib/locales/en-US/index.ts
@@ -693,6 +693,8 @@ export const enUS = {
     segmentsMin: "At least 3 segments",
     segmentsMax: "Maximum 20 segments",
     voiceIdRequired: "Voice ID is required",
+    voiceIdPlaceholder: "e.g. alloy (OpenAI) or Model:Voice (compatible providers)",
+    voiceIdHint: "OpenAI: use a voice name (e.g. alloy, echo, nova). For OpenAI-compatible providers, the format may be ModelName:VoiceName (e.g. FunAudioLLM/CosyVoice2-0.5B:anna). Check your provider's documentation.",
     backstoryRequired: "Backstory is required",
     personalityRequired: "Personality is required",
     speakerCountMin: "At least one speaker is required",

--- a/frontend/src/lib/locales/fr-FR/index.ts
+++ b/frontend/src/lib/locales/fr-FR/index.ts
@@ -693,6 +693,8 @@ export const frFR = {
     segmentsMin: "Au moins 3 segments",
     segmentsMax: "20 segments maximum",
     voiceIdRequired: "L'ID de la voix est requis",
+    voiceIdPlaceholder: "ex. alloy (OpenAI) ou Modèle:Voix (fournisseurs compatibles)",
+    voiceIdHint: "OpenAI : utilisez un nom de voix (ex. alloy, echo, nova). Pour les fournisseurs compatibles OpenAI, le format peut être NomModèle:NomVoix (ex. FunAudioLLM/CosyVoice2-0.5B:anna). Consultez la documentation de votre fournisseur.",
     backstoryRequired: "L'histoire (backstory) est requise",
     personalityRequired: "La personnalité est requise",
     speakerCountMin: "Au moins un intervenant est requis",

--- a/frontend/src/lib/locales/it-IT/index.ts
+++ b/frontend/src/lib/locales/it-IT/index.ts
@@ -693,6 +693,8 @@ export const itIT = {
     segmentsMin: "Almeno 3 segmenti",
     segmentsMax: "Massimo 20 segmenti",
     voiceIdRequired: "L'ID voce è obbligatorio",
+    voiceIdPlaceholder: "es. alloy (OpenAI) o Modello:Voce (provider compatibili)",
+    voiceIdHint: "OpenAI: usa un nome voce (es. alloy, echo, nova). Per i provider compatibili con OpenAI, il formato può essere NomeModello:NomeVoce (es. FunAudioLLM/CosyVoice2-0.5B:anna). Consulta la documentazione del tuo provider.",
     backstoryRequired: "Il background è obbligatorio",
     personalityRequired: "La personalità è obbligatoria",
     speakerCountMin: "È richiesto almeno uno speaker",

--- a/frontend/src/lib/locales/ja-JP/index.ts
+++ b/frontend/src/lib/locales/ja-JP/index.ts
@@ -693,6 +693,8 @@ export const jaJP = {
     segmentsMin: "最低3セグメント",
     segmentsMax: "最大20セグメント",
     voiceIdRequired: "Voice IDは必須です",
+    voiceIdPlaceholder: "例: alloy (OpenAI) または モデル:音声 (互換プロバイダ)",
+    voiceIdHint: "OpenAI: 音声名を使用してください（例: alloy、echo、nova）。OpenAI互換プロバイダの場合、形式はモデル名:音声名になることがあります（例: FunAudioLLM/CosyVoice2-0.5B:anna）。プロバイダのドキュメントを確認してください。",
     backstoryRequired: "バックストーリーは必須です",
     personalityRequired: "パーソナリティは必須です",
     speakerCountMin: "最低1人のスピーカーが必要です",

--- a/frontend/src/lib/locales/pt-BR/index.ts
+++ b/frontend/src/lib/locales/pt-BR/index.ts
@@ -693,6 +693,8 @@ export const ptBR = {
     segmentsMin: "Mínimo de 3 segmentos",
     segmentsMax: "Máximo de 20 segmentos",
     voiceIdRequired: "ID da voz é obrigatório",
+    voiceIdPlaceholder: "ex. alloy (OpenAI) ou Modelo:Voz (provedores compatíveis)",
+    voiceIdHint: "OpenAI: use um nome de voz (ex. alloy, echo, nova). Para provedores compatíveis com OpenAI, o formato pode ser NomeModelo:NomeVoz (ex. FunAudioLLM/CosyVoice2-0.5B:anna). Consulte a documentação do seu provedor.",
     backstoryRequired: "História é obrigatória",
     personalityRequired: "Personalidade é obrigatória",
     speakerCountMin: "Pelo menos um locutor é necessário",

--- a/frontend/src/lib/locales/ru-RU/index.ts
+++ b/frontend/src/lib/locales/ru-RU/index.ts
@@ -693,6 +693,8 @@ export const ruRU = {
     segmentsMin: "Минимум 3 сегмента",
     segmentsMax: "Максимум 20 сегментов",
     voiceIdRequired: "Требуется ID голоса",
+    voiceIdPlaceholder: "напр. alloy (OpenAI) или Модель:Голос (совместимые провайдеры)",
+    voiceIdHint: "OpenAI: используйте имя голоса (напр. alloy, echo, nova). Для OpenAI-совместимых провайдеров формат может быть НазваниеМодели:НазваниеГолоса (напр. FunAudioLLM/CosyVoice2-0.5B:anna). Проверьте документацию вашего провайдера.",
     backstoryRequired: "Требуется биография",
     personalityRequired: "Требуется описание личности",
     speakerCountMin: "Требуется минимум один говорящий",

--- a/frontend/src/lib/locales/zh-CN/index.ts
+++ b/frontend/src/lib/locales/zh-CN/index.ts
@@ -693,6 +693,8 @@ export const zhCN = {
     segmentsMin: "至少包含 3 个分段",
     segmentsMax: "最多包含 20 个分段",
     voiceIdRequired: "必须填写声音 ID",
+    voiceIdPlaceholder: "例如 alloy (OpenAI) 或 模型:声音 (兼容提供商)",
+    voiceIdHint: "OpenAI：使用声音名称（例如 alloy、echo、nova）。对于 OpenAI 兼容提供商，格式可能为 模型名:声音名（例如 FunAudioLLM/CosyVoice2-0.5B:anna）。请查阅您提供商的文档。",
     backstoryRequired: "必须填写背景故事",
     personalityRequired: "必须填写性格描述",
     speakerCountMin: "至少需要一个发言人",

--- a/frontend/src/lib/locales/zh-TW/index.ts
+++ b/frontend/src/lib/locales/zh-TW/index.ts
@@ -693,6 +693,8 @@ export const zhTW = {
     segmentsMin: "至少包含 3 個分段",
     segmentsMax: "最多包含 20 個分段",
     voiceIdRequired: "必須填寫聲音 ID",
+    voiceIdPlaceholder: "例如 alloy (OpenAI) 或 模型:聲音 (相容提供商)",
+    voiceIdHint: "OpenAI：使用聲音名稱（例如 alloy、echo、nova）。對於 OpenAI 相容提供商，格式可能為 模型名:聲音名（例如 FunAudioLLM/CosyVoice2-0.5B:anna）。請查閱您提供商的說明文件。",
     backstoryRequired: "必須填寫背景故事",
     personalityRequired: "必須填寫性格描述",
     speakerCountMin: "至少需要一個發言人",


### PR DESCRIPTION
Fixes #572

## Summary
This PR fixes: [Bug]:  Third-Party TTS Providers Voice ID Configuration Not Intuitive

## Changes
```
frontend/src/components/podcasts/forms/SpeakerProfileFormDialog.tsx | 3 ++-
 frontend/src/lib/locales/en-US/index.ts                             | 2 ++
 frontend/src/lib/locales/fr-FR/index.ts                             | 2 ++
 frontend/src/lib/locales/it-IT/index.ts                             | 2 ++
 frontend/src/lib/locales/ja-JP/index.ts                             | 2 ++
 frontend/src/lib/locales/pt-BR/index.ts                             | 2 ++
 frontend/src/lib/locales/ru-RU/index.ts                             | 2 ++
 frontend/src/lib/locales/zh-CN/index.ts                             | 2 ++
 frontend/src/lib/locales/zh-TW/index.ts                             | 2 ++
 9 files changed, 18 insertions(+), 1 deletion(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*