### PR TITLE
Fix #536: [Bug]: Embedding Fails with Large Sources

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,8 +48,11 @@ SURREAL_DATABASE=open_notebook
 # OLLAMA_BASE_URL=http://ollama:11434
 
 # Content processing
-# CHUNK_SIZE=1500
-# CHUNK_OVERLAP=150
+# OPEN_NOTEBOOK_CHUNK_SIZE=1200
+# OPEN_NOTEBOOK_CHUNK_OVERLAP=180
+
+# Embedding batch size — reduce if your provider rejects large batches (HTTP 400/413)
+# OPEN_NOTEBOOK_EMBEDDING_BATCH_SIZE=50
 
 # Security
 # BASIC_AUTH_USERNAME=admin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Embedding batch size is now configurable via `OPEN_NOTEBOOK_EMBEDDING_BATCH_SIZE` environment variable, allowing users to tune for their embedding provider's per-request limits and preventing HTTP 400 errors with Mistral and other providers (#536)
+
 ## [1.7.4] - 2026-02-18
 
 ### Fixed


### PR DESCRIPTION
Fixes #536

## Summary
This PR fixes: [Bug]: Embedding Fails with Large Sources

## Changes
```
.env.example                     |  7 ++++--
 CHANGELOG.md                     |  3 +++
 open_notebook/utils/embedding.py | 47 +++++++++++++++++++++++++++++++++++++++-
 3 files changed, 54 insertions(+), 3 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: high. Happy to make any adjustments!*