### PR TITLE
fix #605: correct text orientation for CJK characters in collapsible column

### DIFF
--- a/frontend/src/components/notebooks/CollapsibleColumn.tsx
+++ b/frontend/src/components/notebooks/CollapsibleColumn.tsx
@@ -21,6 +21,8 @@ export function CollapsibleColumn({
   collapsedLabel,
   children,
 }: CollapsibleColumnProps) {
+  const isCJK = /[\u4e00-\u9fa5\u3040-\u30ff\uac00-\ud7af]/.test(collapsedLabel);
+
   if (isCollapsed) {
     return (
       <TooltipProvider>
@@ -42,7 +44,7 @@ export function CollapsibleColumn({
               <CollapsedIcon className="h-5 w-5 text-muted-foreground group-hover:text-foreground transition-colors flex-shrink-0" />
               <div
                 className="text-xs font-medium text-muted-foreground group-hover:text-foreground transition-colors whitespace-nowrap"
-                style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)', textOrientation: 'mixed' }}
+                style={{ writingMode: 'vertical-rl', transform: isCJK ? 'none' : 'rotate(180deg)', textOrientation: 'mixed' }}
               >
                 {collapsedLabel}
               </div>


### PR DESCRIPTION
## Description

This PR fixes a UI bug where text in the `CollapsibleColumn` component (such as "来源" or "笔记") was displayed upside down when the interface language was set to Chinese, Japanese, or Korean. 

The issue occurred because a hardcoded `transform: rotate(180deg)` was applied to all languages. While this is necessary for English text to read from bottom-to-top in a `vertical-rl` writing mode, CJK characters are naturally upright in this mode and do not need to be flipped.

I added a regex check (`/[\u4e00-\u9fa5\u3040-\u30ff\uac00-\ud7af]/`) to dynamically detect CJK characters. If true, the transform is set to `none`, otherwise it preserves the `rotate(180deg)` for non-CJK languages.

## Related Issue

Fixes #605 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## How Has This Been Tested?

- [ ] Tested locally with Docker
- [x] Tested locally with development setup
- [ ] Added new unit tests
- [x] Existing tests pass (`uv run pytest`)
- [x] Manual testing performed (describe below)

**Test Details:**
1. Started the frontend dev server locally.
2. Verified the UI rendering for the CollapsibleColumn with Chinese ("来源", "笔记").
3. Verified the UI rendering with Japanese characters.
4. Verified that English text still rotates correctly (180deg).
5. Ran the full Python backend test suite (`uv run pytest`) to ensure no regressions (128/128 passed).

## Design Alignment

**Which design principles does this PR support?** (See [DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md))

- [ ] Privacy First
- [ ] Simplicity Over Features
- [ ] API-First Architecture
- [ ] Multi-Provider Flexibility
- [x] Extensibility Through Standards
- [ ] Async-First for Performance

**Explanation:**
By properly supporting CJK character rendering in vertical writing modes, this PR extends the UI's internationalization (i18n) standards and makes the application accessible to a broader global audience.

## Checklist

### Code Quality
- [ ] My code follows PEP 8 style guidelines (Python)
- [x] My code follows TypeScript best practices (Frontend)
- [ ] I have added type hints to my code (Python)
- [ ] I have added JSDoc comments where appropriate (TypeScript)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

### Testing
- [x] I have added tests that prove my fix is effective or that my feature works (Manual UI testing)
- [x] New and existing unit tests pass locally with my changes
- [ ] I ran linting: `make ruff` or `ruff check . --fix`
- [ ] I ran type checking: `make lint` or `uv run python -m mypy .`

### Documentation
- [ ] I have updated the relevant documentation in `/docs` (if applicable)
- [ ] I have added/updated docstrings for new/modified functions
- [ ] I have updated the API documentation (if API changes were made)
- [ ] I have added comments to complex logic

### Database Changes
- [ ] I have created migration scripts for any database schema changes (in `/migrations`)
- [ ] Migration includes both up and down scripts
- [ ] Migration has been tested locally

### Breaking Changes
- [ ] This PR includes breaking changes
- [ ] I have documented the migration path for users
- [ ] I have updated MIGRATION.md (if applicable)

## Screenshots (if applicable)

**Before:**：
<img width="218" height="995" alt="屏幕截图 2026-02-21 143509" src="https://github.com/user-attachments/assets/89b41e8c-9c42-4c83-a45b-4b54f017d568" />
<img width="341" height="1053" alt="屏幕截图 2026-02-18 231157" src="https://github.com/user-attachments/assets/b7b36cec-1a66-4e74-8b70-1b89adbb04b1" />

**After:**
<img width="201" height="978" alt="屏幕截图 2026-02-21 143455" src="https://github.com/user-attachments/assets/2baf8738-8f6a-42d2-8830-75253bdbb8bf" />
<img width="210" height="978" alt="屏幕截图 2026-02-21 143431" src="https://github.com/user-attachments/assets/b1c794bc-9136-4b2f-89c3-ef0967f56f7f" />

## Additional Context

N/A

## Pre-Submission Verification

Before submitting, please verify:

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have read [DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md)
- [x] This PR addresses an approved issue that was assigned to me
- [x] I have not included unrelated changes in this PR
- [x] My PR title follows conventional commits format (e.g., "feat: add user authentication")
