### PR TITLE
fix(docker): pin SurrealDB version and fix single-container docs

### DIFF
--- a/Dockerfile.single
+++ b/Dockerfile.single
@@ -13,7 +13,10 @@ COPY frontend/ ./
 # Build the frontend
 RUN npm run build
 
-# Stage 2: Backend Builder
+# Stage 2: SurrealDB binary (pinned to v2 to match docker-compose.yml)
+FROM surrealdb/surrealdb:v2 AS surreal-binary
+
+# Stage 4: Backend Builder
 FROM python:3.12-slim-bookworm AS backend-builder
 # Install build dependencies
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends build-essential && rm -rf /var/lib/apt/lists/*
@@ -30,7 +33,7 @@ COPY open_notebook/__init__.py ./open_notebook/__init__.py
 # Install dependencies
 RUN uv sync --frozen --no-dev
 
-# Stage 3: Runtime
+# Stage 5: Runtime
 FROM python:3.12-slim-bookworm AS runtime
 
 # Install runtime dependencies
@@ -42,8 +45,8 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# Install SurrealDB
-RUN curl --proto '=https' --tlsv1.2 -sSf https://install.surrealdb.com | sh
+# Install SurrealDB (copied from pinned v2 image to match docker-compose.yml)
+COPY --from=surreal-binary /surreal /usr/local/bin/surreal
 
 # Install uv (optional but helpful for some scripts)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/

--- a/docs/1-INSTALLATION/single-container.md
+++ b/docs/1-INSTALLATION/single-container.md
@@ -31,7 +31,7 @@ services:
       - OPEN_NOTEBOOK_ENCRYPTION_KEY=change-me-to-a-secret-string
       - SURREAL_URL=ws://localhost:8000/rpc
       - SURREAL_USER=root
-      - SURREAL_PASSWORD=password
+      - SURREAL_PASSWORD=root
       - SURREAL_NAMESPACE=open_notebook
       - SURREAL_DATABASE=open_notebook
     volumes:
@@ -106,7 +106,7 @@ heroku config:set OPEN_NOTEBOOK_ENCRYPTION_KEY=your-secret-key
 | `OPEN_NOTEBOOK_ENCRYPTION_KEY` | Encryption key for credentials (required) | `my-secret-key` |
 | `SURREAL_URL` | Database | `ws://localhost:8000/rpc` |
 | `SURREAL_USER` | DB user | `root` |
-| `SURREAL_PASSWORD` | DB password | `password` |
+| `SURREAL_PASSWORD` | DB password | `root` |
 | `SURREAL_NAMESPACE` | DB namespace | `open_notebook` |
 | `SURREAL_DATABASE` | DB name | `open_notebook` |
 | `API_URL` | External URL (for remote access) | `https://myapp.example.com` |


### PR DESCRIPTION
## Summary

- Replaces the `curl | sh` SurrealDB install in `Dockerfile.single` with a multi-stage build that copies the binary directly from `surrealdb/surrealdb:v2` — the same image used in `docker-compose.yml`. This prevents breakage when the install script pulls a newer SurrealDB version whose syntax is incompatible with existing migrations.
- Fixes `SURREAL_PASSWORD` in `docs/1-INSTALLATION/single-container.md`: the actual password configured in `supervisord.single.conf` is `root`, not `password`.

## Test plan

- [ ] Build `Dockerfile.single` and verify it starts without migration errors
- [ ] Confirm `surreal` binary is available and matches the `v2` tag version
- [ ] Verify single-container docs reflect the correct `SURREAL_PASSWORD=root`

Closes #498