### PR TITLE
chore: bump version to 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-03-10
+
+### Added
+- i18n support for Bengali (bn-IN) (#643)
+- Podcast language support via podcast-creator 0.12.0 (#645)
+- Upgrade default Azure API version for model testing and fetching (#638)
+
+### Fixed
+- Tiktoken network errors in offline/air-gapped Docker deployments — pre-downloads encoding at build time (#264, #622)
+- SurrealDB getting stuck (#656)
+
+### Dependencies
+- Bump esperanto to 2.19.5 (#657)
+- Bump langgraph from 1.0.6 to 1.0.10rc1 (#658)
+- Bump authlib from 1.6.6 to 1.6.7 (#649)
+- Bump lxml-html-clean from 0.4.3 to 0.4.4 (#646)
+- Bump rollup from 4.55.1 to 4.59.0 (#635)
+- Bump minimatch in frontend (#634)
+- Bump tar from 7.5.9 to 7.5.11 (#650, #659)
+
 ## [1.7.4] - 2026-02-18
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,3 @@ See dedicated CLAUDE.md files for detailed guidance:
 - **Issues**: https://github.com/lfnovo/open-notebook/issues
 - **License**: MIT (see LICENSE)
 
----
-
-**Last Updated**: February 2026 | **Project Version**: 1.8.0

--- a/open_notebook/CLAUDE.md
+++ b/open_notebook/CLAUDE.md
@@ -222,7 +222,4 @@ See dedicated CLAUDE.md files for detailed guidance:
 - **Issues**: https://github.com/lfnovo/open-notebook/issues
 - **License**: MIT (see LICENSE)
 
----
-
-**Last Updated**: February 2026 | **Project Version**: 1.7.3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "open-notebook"
-version = "1.8.0"
+version = "1.8.1"
 description = "An open source implementation of a research assistant, inspired by Google Notebook LM"
 authors = [
     {name = "Luis Novo", email = "lfnovo@gmail.com"}


### PR DESCRIPTION
## Summary
- Bump version from 1.8.0 to 1.8.1
- Update CHANGELOG with all changes since v1.8.0 release
- Remove stale "Last Updated / Project Version" footers from CLAUDE.md files

## Changes since v1.8.0

### Added
- i18n support for Bengali (bn-IN) (#643)
- Podcast language support via podcast-creator 0.12.0 (#645)
- Upgrade default Azure API version (#638)

### Fixed
- Tiktoken network errors in offline/air-gapped Docker deployments (#264, #622)
- SurrealDB getting stuck (#656)

### Dependencies
- esperanto 2.19.5, langgraph 1.0.10rc1, authlib 1.6.7, lxml-html-clean 0.4.4, rollup 4.59.0, minimatch, tar 7.5.11