### PR TITLE
feat(lmstudio): add support for LM Studio provider

### DIFF
--- a/api/credentials_service.py
+++ b/api/credentials_service.py
@@ -41,6 +41,7 @@ PROVIDER_ENV_CONFIG: Dict[str, dict] = {
     "voyage": {"required": ["VOYAGE_API_KEY"]},
     "elevenlabs": {"required": ["ELEVENLABS_API_KEY"]},
     "ollama": {"required": ["OLLAMA_API_BASE"]},
+    "lmstudio": {"required": ["LMSTUDIO_API_BASE"]},
     "vertex": {
         "required": ["VERTEX_PROJECT", "VERTEX_LOCATION"],
         "optional": ["GOOGLE_APPLICATION_CREDENTIALS"],
@@ -74,6 +75,7 @@ PROVIDER_MODALITIES: Dict[str, List[str]] = {
     "vertex": ["language", "embedding"],
     "azure": ["language", "embedding", "speech_to_text", "text_to_speech"],
     "openai_compatible": ["language", "embedding", "speech_to_text", "text_to_speech"],
+    "lmstudio": ["language", "embedding"],
 }
 
 
@@ -550,6 +552,31 @@ async def discover_with_config(provider: str, config: dict) -> List[dict]:
                 ]
         except Exception as e:
             logger.warning(f"Failed to discover openai_compatible models: {e}")
+            return []
+
+    if provider == "lmstudio":
+        effective_base = (base_url or "http://localhost:1234/v1").rstrip("/")
+        if not effective_base:
+            return []
+        try:
+            headers = {}
+            if api_key:
+                headers["Authorization"] = f"Bearer {api_key}"
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f"{effective_base}/models",
+                    headers=headers,
+                    timeout=30.0,
+                )
+                response.raise_for_status()
+                data = response.json()
+                return [
+                    {"name": m.get("id", ""), "provider": "lmstudio"}
+                    for m in data.get("data", [])
+                    if m.get("id")
+                ]
+        except Exception as e:
+            logger.warning(f"Failed to discover lmstudio models: {e}")
             return []
 
     if provider == "azure":

--- a/api/routers/models.py
+++ b/api/routers/models.py
@@ -94,6 +94,7 @@ PROVIDER_PRIORITY = [
     "xai",
     "openrouter",
     "ollama",
+    "lmstudio",
     "azure",
     "openai_compatible",
 ]
@@ -378,6 +379,7 @@ async def get_provider_availability():
             "voyage": "VOYAGE_API_KEY",
             "elevenlabs": "ELEVENLABS_API_KEY",
             "ollama": "OLLAMA_API_BASE",
+            "lmstudio": "LMSTUDIO_API_BASE",
         }
 
         provider_status = {}

--- a/frontend/src/app/(dashboard)/settings/api-keys/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/api-keys/page.tsx
@@ -75,13 +75,14 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   azure: 'Azure OpenAI',
   vertex: 'Google Vertex AI',
   openai_compatible: 'OpenAI Compatible',
+  lmstudio: 'LM Studio',
 }
 
 // All providers in display order
 const ALL_PROVIDERS = [
   'openai', 'anthropic', 'google', 'groq', 'mistral', 'deepseek',
   'xai', 'openrouter', 'voyage', 'elevenlabs', 'ollama',
-  'azure', 'vertex', 'openai_compatible',
+  'lmstudio', 'azure', 'vertex', 'openai_compatible',
 ]
 
 // Default modalities per provider
@@ -100,6 +101,7 @@ const PROVIDER_MODALITIES: Record<string, ModelType[]> = {
   azure: ['language', 'embedding', 'text_to_speech', 'speech_to_text'],
   vertex: ['language', 'embedding', 'text_to_speech'],
   openai_compatible: ['language', 'embedding', 'text_to_speech', 'speech_to_text'],
+  lmstudio: ['language', 'embedding'],
 }
 
 // Documentation links
@@ -117,6 +119,7 @@ const PROVIDER_DOCS: Record<string, string> = {
   azure: 'https://portal.azure.com/#view/Microsoft_Azure_ProjectOxford/CognitiveServicesHub/~/OpenAI',
   vertex: 'https://cloud.google.com/vertex-ai/docs/start/cloud-environment',
   openai_compatible: 'https://github.com/lfnovo/open-notebook/blob/main/docs/5-CONFIGURATION/openai-compatible.md',
+  lmstudio: 'https://lmstudio.ai/docs',
 }
 
 const TYPE_ICONS: Record<ModelType, React.ReactNode> = {
@@ -166,7 +169,8 @@ function CredentialFormDialog({
   const isVertex = provider === 'vertex'
   const isOllama = provider === 'ollama'
   const isOpenAICompatible = provider === 'openai_compatible'
-  const requiresApiKey = !isVertex && !isOllama && !isOpenAICompatible
+  const isLmStudio = provider === 'lmstudio'
+  const requiresApiKey = !isVertex && !isOllama && !isOpenAICompatible && !isLmStudio
 
   const [name, setName] = useState('')
   const [apiKey, setApiKey] = useState('')
@@ -353,7 +357,13 @@ function CredentialFormDialog({
                 className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
                 value={baseUrl}
                 onChange={(e) => setBaseUrl(e.target.value)}
-                placeholder={isOllama ? 'http://localhost:11434' : 'https://api.example.com/v1'}
+                placeholder={
+                  isOllama
+                    ? 'http://localhost:11434'
+                    : isLmStudio
+                      ? 'http://localhost:1234/v1'
+                      : 'https://api.example.com/v1'
+                }
                 disabled={isSubmitting}
               />
               <p className="text-xs text-muted-foreground">{t.apiKeys.baseUrlOverrideHint}</p>

--- a/open_notebook/ai/connection_tester.py
+++ b/open_notebook/ai/connection_tester.py
@@ -34,6 +34,7 @@ TEST_MODELS = {
     "vertex": ("gemini-2.0-flash", "language"),  # Uses Google Vertex AI
     "azure": ("gpt-35-turbo", "language"),  # Azure OpenAI deployment name
     "openai_compatible": (None, "language"),  # Dynamic - will use first available model
+    "lmstudio": (None, "language"),
 }
 
 
@@ -213,11 +214,17 @@ async def test_provider_connection(
             return await _test_ollama_connection(test_base_url)
 
         if normalized_provider == "openai_compatible":
-            # Use base_url from specific config, or environment variable
             test_base_url = base_url or os.environ.get("OPENAI_COMPATIBLE_BASE_URL")
             test_api_key = api_key or os.environ.get("OPENAI_COMPATIBLE_API_KEY")
             if not test_base_url:
                 return False, "No base URL configured for OpenAI-compatible provider"
+            return await _test_openai_compatible_connection(test_base_url, test_api_key)
+
+        if normalized_provider == "lmstudio":
+            test_base_url = base_url or os.environ.get("LMSTUDIO_API_BASE")
+            test_api_key = api_key or os.environ.get("LMSTUDIO_API_KEY")
+            if not test_base_url:
+                test_base_url = "http://localhost:1234/v1"
             return await _test_openai_compatible_connection(test_base_url, test_api_key)
 
         if normalized_provider == "azure":
@@ -307,6 +314,7 @@ DEFAULT_TEST_VOICES = {
     "google": "Kore",
     "vertex": "Kore",
     "openai_compatible": "alloy",
+    "lmstudio": "alloy",
 }
 
 

--- a/open_notebook/ai/key_provider.py
+++ b/open_notebook/ai/key_provider.py
@@ -62,6 +62,9 @@ PROVIDER_CONFIG = {
     "ollama": {
         "env_var": "OLLAMA_API_BASE",
     },
+    "lmstudio": {
+        "env_var": "LMSTUDIO_API_BASE",
+    },
 }
 
 

--- a/open_notebook/ai/model_discovery.py
+++ b/open_notebook/ai/model_discovery.py
@@ -582,6 +582,64 @@ async def discover_openai_compatible_models() -> List[DiscoveredModel]:
     return models
 
 
+async def discover_lmstudio_models() -> List[DiscoveredModel]:
+    api_key = None
+    base_url = None
+
+    try:
+        credentials = await Credential.get_by_provider("lmstudio")
+        if credentials:
+            cred = credentials[0]
+            config = cred.to_esperanto_config()
+            api_key = config.get("api_key")
+            base_url = config.get("base_url", "").rstrip("/")
+    except Exception as e:
+        logger.warning(f"Failed to read lmstudio config from Credential: {e}")
+
+    if not api_key:
+        api_key = os.environ.get("LMSTUDIO_API_KEY")
+    if not base_url:
+        env_base = os.environ.get("LMSTUDIO_API_BASE", "").rstrip("/")
+        base_url = env_base or "http://localhost:1234/v1"
+
+    if not base_url:
+        logger.warning("No base_url configured for lmstudio provider")
+        return []
+
+    models: List[DiscoveredModel] = []
+    try:
+        async with httpx.AsyncClient() as client:
+            headers = {}
+            if api_key:
+                headers["Authorization"] = f"Bearer {api_key}"
+
+            response = await client.get(
+                f"{base_url}/models",
+                headers=headers,
+                timeout=30.0,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            for model in data.get("data", []):
+                model_id = model.get("id", "")
+                if model_id:
+                    model_type = classify_model_type(model_id, "openai")
+                    models.append(
+                        DiscoveredModel(
+                            name=model_id,
+                            provider="lmstudio",
+                            model_type=model_type,
+                        )
+                    )
+    except httpx.HTTPStatusError as e:
+        logger.warning(f"Failed to discover lmstudio models: HTTP {e.response.status_code}")
+    except Exception as e:
+        logger.warning(f"Failed to discover lmstudio models: {e}")
+
+    return models
+
+
 # =============================================================================
 # Main Discovery Functions
 # =============================================================================
@@ -600,6 +658,7 @@ PROVIDER_DISCOVERY_FUNCTIONS = {
     "voyage": discover_voyage_models,
     "elevenlabs": discover_elevenlabs_models,
     "openai_compatible": discover_openai_compatible_models,
+    "lmstudio": discover_lmstudio_models,
     "azure": None,  # Azure requires credential-based discovery (different auth)
     "vertex": None,  # Vertex requires credential-based discovery (service account)
 }

--- a/open_notebook/ai/models.py
+++ b/open_notebook/ai/models.py
@@ -141,13 +141,13 @@ class ModelManager:
 
             await provision_provider_keys(model.provider)
 
-        # Merge any additional kwargs (e.g. temperature)
         config.update(kwargs)
 
-        # Normalize provider name: DB stores underscores but Esperanto expects hyphens
         provider = model.provider.replace("_", "-")
 
-        # Create model based on type (Esperanto will cache the instance)
+        if provider == "lmstudio":
+            provider = "openai-compatible"
+
         if model.type == "language":
             return AIFactory.create_language(
                 model_name=model.name,


### PR DESCRIPTION
## Description

This PR adds **LM Studio** as a first-class local AI provider, while internally routing all requests through the existing `openai-compatible` Esperanto provider.  
The implementation reuses the existing patterns for credentials, model discovery, connection testing, and the models/settings UI:

- New `lmstudio` provider name in the backend (credentials service, provider availability, discovery, connection tester) mapped to `openai-compatible` only at the Esperanto factory boundary.
- Support for listing LM Studio models via the standard OpenAI-style `/v1/models` endpoint, with type classification based on existing OpenAI naming heuristics.
- New LM Studio provider section in the “API Keys / Models” settings page, with optional API key and a default base URL of `http://localhost:1234/v1`.

## Related Issue

Fixes #<!-- issue number -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## How Has This Been Tested?

- [x] Tested locally with Docker
- [ ] Tested locally with development setup
- [ ] Added new unit tests
- [x] Existing tests pass (`uv run pytest`)
- [x] Manual testing performed (describe below)

**Test Details:**

- Ran `uv run pytest` from the project root: all 129 tests passed.
- Ran the full Docker stack and configured an LM Studio credential via the “API Keys / Models” settings page using `http://host.docker.internal:1234/v1` as the base URL.
- Verified that credential testing succeeds for LM Studio.
- Discovered models from LM Studio and registered them; confirmed they appear in the global models list and can be selected as default chat/embedding models.
- Performed a chat session.

## Design Alignment

**Which design principles does this PR support?**

- [ ] Privacy First
- [x] Simplicity Over Features
- [x] API-First Architecture
- [x] Multi-Provider Flexibility
- [x] Extensibility Through Standards
- [x] Async-First for Performance

**Explanation:**

- **Simplicity Over Features / Extensibility Through Standards:** LM Studio is integrated via the existing `openai-compatible` path instead of introducing a bespoke client, keeping the surface area small while leveraging a standard API shape.
- **API-First Architecture / Multi-Provider Flexibility:** The change wires LM Studio into the same provider/credential/model discovery abstractions used for other providers, so it can be configured, discovered, and selected like any other model source.
- **Async-First for Performance:** All new network interactions (discovery and connection testing) follow the existing async HTTP patterns and reuse the current concurrency model.

## Checklist

### Code Quality
- [ ] My code follows PEP 8 style guidelines (Python)
- [ ] My code follows TypeScript best practices (Frontend)
- [x] I have added type hints to my code (Python) where new functions were introduced
- [ ] I have added JSDoc comments where appropriate (TypeScript)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors

### Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I ran linting: `make ruff` or `ruff check . --fix`
- [ ] I ran type checking: `make lint` or `uv run python -m mypy .`

### Documentation
- [ ] I have updated the relevant documentation in `/docs` (if applicable)
- [ ] I have added/updated docstrings for new/modified functions
- [ ] I have updated the API documentation (if API changes were made)
- [ ] I have added comments to complex logic

### Database Changes
- [x] This PR does not include any database schema changes
- [ ] I have created migration scripts for any database schema changes (in `/migrations`)
- [ ] Migration includes both up and down scripts
- [ ] Migration has been tested locally

### Breaking Changes
- [x] This PR does not include breaking changes
- [ ] This PR includes breaking changes
- [ ] I have documented the migration path for users
- [ ] I have updated MIGRATION.md (if applicable)

## Screenshots (if applicable)

N/A – UI changes are limited to adding LM Studio as a new provider entry in the existing “API Keys / Models” settings page.
<img width="464" height="539" alt="image" src="https://github.com/user-attachments/assets/f968d30f-bdfc-4319-b513-7be3ab877104" />
<img width="1392" height="715" alt="image" src="https://github.com/user-attachments/assets/1f67f1f9-01d9-4ed5-a65d-cdd317005fd2" />

<img width="1394" height="167" alt="image" src="https://github.com/user-attachments/assets/b4a78045-243b-4534-8838-28c4de940072" />

## Additional Context

- LM Studio is treated as a separate provider (`lmstudio`) in the database, credentials, and UI, but is mapped to `openai-compatible` only when instantiating Esperanto models. This keeps the data model explicit while maximizing reuse of the existing provider plumbing.
- The default base URL `http://localhost:1234/v1` matches LM Studio’s OpenAI-compatible endpoint configuration shown in its UI, and can be overridden via credentials if needed.

## Pre-Submission Verification

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have read [DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md)
- [ ] This PR addresses an approved issue that was assigned to me (replace the issue number above once confirmed)
- [x] I have not included unrelated changes in this PR
- [ ] My PR title follows conventional commits format (e.g., "feat: add user authentication")