### PR TITLE
feat: add MiniMax as a native AI provider

### DIFF
--- a/docs/5-CONFIGURATION/ai-providers.md
+++ b/docs/5-CONFIGURATION/ai-providers.md
@@ -249,6 +249,43 @@ Heavy use: Depends on models chosen
 
 ---
 
+### MiniMax
+
+**Cost:** ~$0.20-1.00 per 1M tokens
+
+**Get Your API Key:**
+1. Go to https://platform.minimaxi.com/
+2. Create account or login
+3. Go to API keys section
+4. Create new API key
+
+**Configure in Open Notebook:**
+1. Go to **Settings** → **API Keys**
+2. Click **Add Credential**
+3. Select provider: **MiniMax**
+4. Give it a name, paste your API key
+5. Click **Save**, then **Test Connection**
+6. Manually register models (model discovery not supported)
+
+**Available Models:**
+- `MiniMax-M2.5` — Latest flagship model (204K context)
+- `MiniMax-M2.5-highspeed` — Faster variant (204K context)
+
+**Recommended:**
+- For quality: `MiniMax-M2.5` (best overall)
+- For speed: `MiniMax-M2.5-highspeed` (faster, same context)
+
+**Advantages:**
+- Very large context window (204K tokens)
+- Competitive pricing
+- OpenAI-compatible API
+
+**Troubleshooting:**
+- "Invalid API key" → Check the key at platform.minimaxi.com
+- "Rate limited" → Wait or upgrade account
+
+---
+
 ## Self-Hosted / Local
 
 ### Ollama (Recommended for Local)

--- a/docs/5-CONFIGURATION/environment-reference.md
+++ b/docs/5-CONFIGURATION/environment-reference.md
@@ -247,6 +247,7 @@ If you have these variables configured from a previous installation, click the *
 | `GROQ_API_KEY` | Groq | Settings → API Keys → Add Groq Credential |
 | `MISTRAL_API_KEY` | Mistral | Settings → API Keys → Add Mistral Credential |
 | `DEEPSEEK_API_KEY` | DeepSeek | Settings → API Keys → Add DeepSeek Credential |
+| `MINIMAX_API_KEY` | MiniMax | Settings → API Keys → Add MiniMax Credential |
 | `XAI_API_KEY` | xAI | Settings → API Keys → Add xAI Credential |
 | `OLLAMA_API_BASE` | Ollama | Settings → API Keys → Add Ollama Credential |
 | `OPENROUTER_API_KEY` | OpenRouter | Settings → API Keys → Add OpenRouter Credential |

--- a/frontend/src/app/(dashboard)/settings/api-keys/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/api-keys/page.tsx
@@ -74,6 +74,7 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   ollama: 'Ollama',
   azure: 'Azure OpenAI',
   vertex: 'Google Vertex AI',
+  minimax: 'MiniMax',
   openai_compatible: 'OpenAI Compatible',
 }
 
@@ -81,7 +82,7 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
 const ALL_PROVIDERS = [
   'openai', 'anthropic', 'google', 'groq', 'mistral', 'deepseek',
   'xai', 'openrouter', 'voyage', 'elevenlabs', 'ollama',
-  'azure', 'vertex', 'openai_compatible',
+  'minimax', 'azure', 'vertex', 'openai_compatible',
 ]
 
 // Default modalities per provider
@@ -97,6 +98,7 @@ const PROVIDER_MODALITIES: Record<string, ModelType[]> = {
   voyage: ['embedding'],
   elevenlabs: ['text_to_speech', 'speech_to_text'],
   ollama: ['language', 'embedding'],
+  minimax: ['language'],
   azure: ['language', 'embedding', 'text_to_speech', 'speech_to_text'],
   vertex: ['language', 'embedding', 'text_to_speech'],
   openai_compatible: ['language', 'embedding', 'text_to_speech', 'speech_to_text'],
@@ -114,6 +116,7 @@ const PROVIDER_DOCS: Record<string, string> = {
   openrouter: 'https://openrouter.ai/keys',
   voyage: 'https://dash.voyageai.com/api-keys',
   elevenlabs: 'https://elevenlabs.io/app/settings/api-keys',
+  minimax: 'https://platform.minimaxi.com/',
   azure: 'https://portal.azure.com/#view/Microsoft_Azure_ProjectOxford/CognitiveServicesHub/~/OpenAI',
   vertex: 'https://cloud.google.com/vertex-ai/docs/start/cloud-environment',
   openai_compatible: 'https://github.com/lfnovo/open-notebook/blob/main/docs/5-CONFIGURATION/openai-compatible.md',

--- a/open_notebook/ai/connection_tester.py
+++ b/open_notebook/ai/connection_tester.py
@@ -34,6 +34,7 @@ TEST_MODELS = {
     "vertex": ("gemini-2.0-flash", "language"),  # Uses Google Vertex AI
     "azure": ("gpt-35-turbo", "language"),  # Azure OpenAI deployment name
     "openai_compatible": (None, "language"),  # Dynamic - will use first available model
+    "minimax": ("MiniMax-M2.5-highspeed", "language"),  # MiniMax via OpenAI-compatible
 }
 
 
@@ -218,6 +219,14 @@ async def test_provider_connection(
             test_api_key = api_key or os.environ.get("OPENAI_COMPATIBLE_API_KEY")
             if not test_base_url:
                 return False, "No base URL configured for OpenAI-compatible provider"
+            return await _test_openai_compatible_connection(test_base_url, test_api_key)
+
+        if normalized_provider == "minimax":
+            # MiniMax uses OpenAI-compatible API
+            test_base_url = base_url or "https://api.minimax.io/v1"
+            test_api_key = api_key or os.environ.get("MINIMAX_API_KEY")
+            if not test_api_key:
+                return False, "No API key configured for MiniMax"
             return await _test_openai_compatible_connection(test_base_url, test_api_key)
 
         if normalized_provider == "azure":

--- a/open_notebook/ai/key_provider.py
+++ b/open_notebook/ai/key_provider.py
@@ -58,6 +58,9 @@ PROVIDER_CONFIG = {
     "elevenlabs": {
         "env_var": "ELEVENLABS_API_KEY",
     },
+    "minimax": {
+        "env_var": "MINIMAX_API_KEY",
+    },
     # URL-based providers
     "ollama": {
         "env_var": "OLLAMA_API_BASE",

--- a/open_notebook/ai/models.py
+++ b/open_notebook/ai/models.py
@@ -147,6 +147,15 @@ class ModelManager:
         # Normalize provider name: DB stores underscores but Esperanto expects hyphens
         provider = model.provider.replace("_", "-")
 
+        # Map providers that use OpenAI-compatible API to the openai-compatible provider
+        OPENAI_COMPATIBLE_PROVIDERS = {
+            "minimax": "https://api.minimax.io/v1",
+        }
+        if provider in OPENAI_COMPATIBLE_PROVIDERS:
+            if "base_url" not in config:
+                config["base_url"] = OPENAI_COMPATIBLE_PROVIDERS[provider]
+            provider = "openai-compatible"
+
         # Create model based on type (Esperanto will cache the instance)
         if model.type == "language":
             return AIFactory.create_language(


### PR DESCRIPTION
## Summary

Add [MiniMax](https://platform.minimaxi.com/) as a first-class AI provider. MiniMax offers OpenAI-compatible LLM models with 204K token context windows at competitive pricing.

**Supported models:**
- `MiniMax-M2.5` — Flagship model (204K context)
- `MiniMax-M2.5-highspeed` — Faster variant (204K context)

## Changes

### Backend
- **`open_notebook/ai/key_provider.py`**: Add `minimax` to `PROVIDER_CONFIG` with `MINIMAX_API_KEY` env var
- **`open_notebook/ai/models.py`**: Map `minimax` provider to `openai-compatible` in `ModelManager` with default `base_url=https://api.minimax.io/v1` — this lets MiniMax work through Esperanto's existing OpenAI-compatible provider without requiring changes to the Esperanto library
- **`open_notebook/ai/connection_tester.py`**: Add `minimax` to `TEST_MODELS` dict and add dedicated connection test handler that uses the OpenAI-compatible test path with MiniMax's base URL

### Frontend
- **`frontend/src/app/(dashboard)/settings/api-keys/page.tsx`**: Add MiniMax to `PROVIDER_DISPLAY_NAMES`, `ALL_PROVIDERS`, `PROVIDER_MODALITIES` (language), and `PROVIDER_DOCS`

### Documentation
- **`docs/5-CONFIGURATION/ai-providers.md`**: Add MiniMax setup guide with available models, pricing, and troubleshooting
- **`docs/5-CONFIGURATION/environment-reference.md`**: Add `MINIMAX_API_KEY` env var reference

## How it works

MiniMax provides an OpenAI-compatible API at `https://api.minimax.io/v1`. Rather than adding a new Esperanto provider, this PR maps the `minimax` provider name to `openai-compatible` in the `ModelManager`, automatically setting the correct base URL. This approach:

1. Requires zero changes to the Esperanto library
2. Follows the same pattern that could be used for other OpenAI-compatible providers
3. Gives users a dedicated "MiniMax" option in the UI instead of requiring manual OpenAI-Compatible setup

## Test plan

- [ ] Verify MiniMax appears in Settings → API Keys provider list
- [ ] Add MiniMax credential with API key, test connection
- [ ] Register MiniMax-M2.5 or MiniMax-M2.5-highspeed model
- [ ] Use the model in a chat conversation
- [ ] Verify env var fallback works with `MINIMAX_API_KEY`