### PR TITLE
fix: map base_url to endpoint for Azure credentials

### DIFF
--- a/docs/3-USER-GUIDE/api-configuration.md
+++ b/docs/3-USER-GUIDE/api-configuration.md
@@ -107,7 +107,7 @@ Navigation: Settings → API Keys
 
 | Provider | Required Fields | Optional Fields |
 |----------|-----------------|-----------------|
-| Azure OpenAI | API Key, Endpoint, API Version | Service-specific endpoints (LLM, Embedding, STT, TTS) |
+| Azure OpenAI | API Key, URL Base (Azure endpoint) | Service-specific endpoints (LLM, Embedding, STT, TTS) |
 | OpenAI-Compatible | Base URL | API Key, Service-specific configs |
 | Vertex AI | Project ID, Location, Credentials Path | — |
 
@@ -208,17 +208,13 @@ Ollama allows localhost and private IPs since it runs locally.
 
 ### Azure OpenAI
 
-Azure requires multiple fields:
+1. Add credential with provider **Azure OpenAI**
+2. Enter your API key
+3. Enter your Azure endpoint in the **URL Base** field (e.g., `https://myresource.openai.azure.com`)
+4. Test connection
+5. Discover and register models
 
-| Field | Example | Required |
-|-------|---------|----------|
-| API Key | `abc123...` | Yes |
-| Endpoint | `https://myresource.openai.azure.com` | Yes |
-| API Version | `2024-02-15-preview` | Yes |
-| LLM Endpoint | `https://myresource-llm.openai.azure.com` | No |
-| Embedding Endpoint | `https://myresource-embed.openai.azure.com` | No |
-
-Service-specific endpoints override the main endpoint for that service type.
+The URL Base field is automatically mapped to the Azure endpoint. The API version defaults to `2024-10-21` if not set via environment variable.
 
 ### OpenAI-Compatible
 
@@ -377,8 +373,8 @@ API keys stored in the database are encrypted using Fernet (AES-128-CBC + HMAC-S
 - Ensure Ollama server is running
 
 ### Azure OpenAI
-- Endpoint format: `https://{resource-name}.openai.azure.com`
-- API version format: `YYYY-MM-DD` or `YYYY-MM-DD-preview`
+- Enter your Azure endpoint in the **URL Base** field (format: `https://{resource-name}.openai.azure.com`)
+- API version defaults to `2024-10-21`; override via `AZURE_OPENAI_API_VERSION` environment variable if needed
 - Deployment names configured separately when registering models via the credential's Discover Models dialog
 
 ---

--- a/open_notebook/ai/connection_tester.py
+++ b/open_notebook/ai/connection_tester.py
@@ -223,7 +223,9 @@ async def test_provider_connection(
             return await _test_openai_compatible_connection(test_base_url, test_api_key)
 
         if normalized_provider == "azure":
-            return await _test_azure_connection(endpoint, api_key, api_version)
+            # For Azure, base_url from the UI form maps to endpoint
+            azure_endpoint = endpoint or base_url
+            return await _test_azure_connection(azure_endpoint, api_key, api_version)
 
         # Get test model for provider
         if normalized_provider not in TEST_MODELS:

--- a/open_notebook/ai/key_provider.py
+++ b/open_notebook/ai/key_provider.py
@@ -190,8 +190,10 @@ async def _provision_azure() -> bool:
         os.environ["AZURE_OPENAI_API_VERSION"] = cred.api_version
         logger.debug("Set AZURE_OPENAI_API_VERSION from Credential")
         any_set = True
-    if cred.endpoint:
-        os.environ["AZURE_OPENAI_ENDPOINT"] = cred.endpoint
+    # For Azure, base_url from the UI form maps to endpoint
+    azure_endpoint = cred.endpoint or cred.base_url
+    if azure_endpoint:
+        os.environ["AZURE_OPENAI_ENDPOINT"] = azure_endpoint
         logger.debug("Set AZURE_OPENAI_ENDPOINT from Credential")
         any_set = True
     if cred.endpoint_llm:

--- a/open_notebook/domain/credential.py
+++ b/open_notebook/domain/credential.py
@@ -76,6 +76,9 @@ class Credential(ObjectModel):
             config["api_key"] = self.api_key.get_secret_value()
         if self.base_url:
             config["base_url"] = self.base_url
+            # For Azure, base_url from the UI form maps to endpoint
+            if self.provider and self.provider.lower() == "azure" and not self.endpoint:
+                config["endpoint"] = self.base_url
         if self.endpoint:
             config["endpoint"] = self.endpoint
         if self.api_version:


### PR DESCRIPTION
## Summary

- Maps `base_url` from the UI credential form to Azure's `endpoint` parameter across connection tester, key provisioner, and Esperanto config
- Allows Azure credentials to work using the existing "URL Base" form field without needing a dedicated endpoint field
- `api_version` already defaults to `2024-10-21` (current GA version), no change needed

## Changes

- **connection_tester.py**: Use `base_url` as fallback for `endpoint` when testing Azure connections
- **key_provider.py**: Use `base_url` as fallback for `endpoint` when provisioning Azure env vars
- **credential.py**: In `to_esperanto_config()`, map `base_url` → `endpoint` for Azure when `endpoint` is not set

Closes #727